### PR TITLE
Fix MCP stdio compliance; add initialize.instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ This design eliminates the race condition that occurred when multiple Claude Cod
 
 ## State Directory
 
-The daemon stores its runtime state in `/tmp/mcp-communicator-telegram-$USER/`:
+The daemon stores its runtime state in `/tmp/mcp-communicator-telegram-<token-hash>/`, where `<token-hash>` is the first 8 hex chars of `sha256(TELEGRAM_TOKEN)`. Keying by token (not by user) means any OS user pointing at a wrapper that resolves the same token reuses the same daemon — Telegram's `getUpdates` is mutually exclusive at the bot-token level, so per-user daemons would compete for the same poll and lose updates. Different bots get different hashes and run side by side.
+
+The dir is created mode `2770` (setgid + group `rwx`) with group `sudo`, so any sudo member can spawn / inspect / clean it. Files inside inherit `gid=sudo` via setgid and are mode `0o660`. `server.log` therefore contains Q/A bodies readable inside the sudo group — fine on a host where credentials are already shared inside that group, not fine on a generic multi-user host.
 
 | File | Purpose |
 |------|---------|
@@ -241,14 +243,14 @@ If the daemon gets into a bad state (e.g., port conflict, stale PID file, Telegr
 
 ```bash
 pkill -f 'node.*build/index.js'
-rm -rf /tmp/mcp-communicator-telegram-$USER
+rm -rf /tmp/mcp-communicator-telegram-*
 ```
 
 The next MCP tool call from any Claude Code session will spawn a fresh daemon.
 
 Other common issues:
 
-- **Daemon not starting**: Check `/tmp/mcp-communicator-telegram-$USER/server.log` for error output.
+- **Daemon not starting**: Check `/tmp/mcp-communicator-telegram-<token-hash>/server.log` for error output.
 - **Bot not responding to replies**: Ensure `CHAT_ID` in `.env` matches the chat where you are replying. The bot only accepts messages from the configured chat ID.
 - **Port range exhausted**: All ports 13579–13588 are in use. Either free a port or set `MCP_HTTP_PORT` to an available range start.
 
@@ -291,4 +293,6 @@ qpd-v
 
 ## Version
 
-0.3.0 — First release with the shared HTTP daemon, stdio wrapper (`bin/mcp-client.sh`), state directory (`/tmp/mcp-communicator-telegram-$USER`), and reply-only question routing.
+0.3.0 — First release with the shared HTTP daemon, stdio wrapper (`bin/mcp-client.sh`), per-user state directory, and reply-only question routing.
+
+0.3.1 — State directory keyed by `sha256(TELEGRAM_TOKEN)` only (no `$USER`), mode `2770` group `sudo`, so all sudo members sharing a token share one daemon instead of competing for Telegram's exclusive long poll.

--- a/README.md
+++ b/README.md
@@ -2,41 +2,45 @@
 
 An MCP server that enables communication with users through Telegram. This server provides tools to interact with users via a Telegram bot, including asking questions, sending notifications, sharing files, and creating project archives.
 
-## Installation
+## Architecture
 
-### Via npm (global)
+Starting with v0.3.0, this project runs as a **singleton HTTP daemon** rather than a per-session stdio process.
+
+How it works:
+
+- `bin/mcp-client.sh` is the stdio entry point that each Claude Code session connects to.
+- On first use, the wrapper lazily spawns a background Node.js HTTP daemon (`build/index.js`).
+- Subsequent Claude Code sessions detect the running daemon and reuse it instead of starting a new one.
+- All MCP tool calls are forwarded from the wrapper to the daemon over HTTP on localhost.
+
+This design eliminates the race condition that occurred when multiple Claude Code sessions competed for the Telegram bot polling lock.
+
+## State Directory
+
+The daemon stores its runtime state in `~/.mcp-communicator-telegram/`:
+
+| File | Purpose |
+|------|---------|
+| `server.pid` | PID of the running daemon |
+| `server.port` | Port the daemon is listening on |
+| `server.log` | Daemon stdout/stderr log |
+| `spawn.lock` | Lock file used during daemon startup |
+
+## Port Selection
+
+The daemon binds to the first available port in the range **13579–13588** (inclusive). If all ports in the range are occupied, startup fails with an error.
+
+To force a specific starting port, set the `MCP_HTTP_PORT` environment variable:
 
 ```bash
-npm install -g mcp-communicator-telegram
+MCP_HTTP_PORT=13600 bin/mcp-client.sh
 ```
-
-### Via npx (on-demand)
-
-```bash
-npx mcptelegram
-```
-
-To get your Telegram chat ID:
-```bash
-npx mcptelegram-chatid
-```
-
-## Features
-
-- Ask questions to users through Telegram
-- Send notifications to users (no response required)
-- Send files to users via Telegram
-- Create and send project zip files (respecting .gitignore)
-- Receive responses asynchronously (waits indefinitely for response)
-- Support for reply-based message tracking
-- Secure chat ID validation
-- Error handling and logging
 
 ## Prerequisites
 
 - Node.js (v14 or higher)
 - A Telegram bot token (obtained from [@BotFather](https://t.me/botfather))
-- Your Telegram chat ID (can be obtained using the included utility)
+- Your Telegram chat ID (see below)
 
 ## Installation
 
@@ -46,9 +50,10 @@ git clone https://github.com/qpd-v/mcp-communicator-telegram.git
 cd mcp-communicator-telegram
 ```
 
-2. Install dependencies:
+2. Install dependencies and build:
 ```bash
 npm install
+npm run build
 ```
 
 3. Create a Telegram bot:
@@ -64,10 +69,9 @@ npm install
      ```
    - Run the chat ID utility:
      ```bash
-     npm run build
      node build/get-chat-id.js
      ```
-   - Send any message to your bot
+   - Send any message to your bot in Telegram
    - Copy the chat ID that appears in the console
    - Add the chat ID to your `.env` file:
      ```
@@ -77,28 +81,30 @@ npm install
 
 ## Configuration
 
-Add the server to your MCP settings file (usually located at `%APPDATA%\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\cline_mcp_settings.json` on Windows):
+Add the server to your `.mcp.json` (or equivalent MCP settings file), pointing the `command` at the wrapper script:
 
 ```json
 {
   "mcpServers": {
     "mcp-communicator-telegram": {
-      "command": "node",
-      "args": ["path/to/mcp-communicator-telegram/build/index.js"],
-      "env": {
-        "TELEGRAM_TOKEN": "your_bot_token_here",
-        "CHAT_ID": "your_chat_id_here"
-      }
+      "type": "stdio",
+      "command": "/path/to/mcp-communicator-telegram/bin/mcp-client.sh"
     }
   }
 }
 ```
+
+Replace `/path/to/mcp-communicator-telegram` with the absolute path to your checkout.
+
+The wrapper reads `TELEGRAM_TOKEN` and `CHAT_ID` from the `.env` file in the project root, so no additional `env` block is needed in most setups.
 
 ## Available Tools
 
 ### ask_user
 
 Asks a question to the user via Telegram and waits for their response.
+
+**Important:** Only Telegram messages sent as a **Reply** to the bot's question message will resolve the pending `ask_user` call. Plain (non-reply) messages sent to the bot are logged and ignored. This prevents accidental responses from being mistaken for answers.
 
 Input Schema:
 ```json
@@ -229,6 +235,23 @@ Features:
 - Automatically cleans up the zip file after sending
 - Handles files up to 2GB in size
 
+## Reset / Troubleshooting
+
+If the daemon gets into a bad state (e.g., port conflict, stale PID file, Telegram polling error), force a clean restart:
+
+```bash
+pkill -f 'node.*build/index.js'
+rm -rf ~/.mcp-communicator-telegram
+```
+
+The next MCP tool call from any Claude Code session will spawn a fresh daemon.
+
+Other common issues:
+
+- **Daemon not starting**: Check `~/.mcp-communicator-telegram/server.log` for error output.
+- **Bot not responding to replies**: Ensure `CHAT_ID` in `.env` matches the chat where you are replying. The bot only accepts messages from the configured chat ID.
+- **Port range exhausted**: All ports 13579–13588 are in use. Either free a port or set `MCP_HTTP_PORT` to an available range start.
+
 ## Development
 
 Build the project:
@@ -256,7 +279,7 @@ npm run clean
 - The server only responds to messages from the configured chat ID
 - Environment variables are used for sensitive configuration
 - Message IDs are used to track question/answer pairs
-- The bot ignores messages without proper context
+- The bot ignores messages that are not replies to its own questions
 
 ## License
 
@@ -268,4 +291,4 @@ qpd-v
 
 ## Version
 
-0.2.1  # Major version bump for new features: notify_user, send_file, and zip_project tools
+0.3.0 — First release with the shared HTTP daemon, stdio wrapper (`bin/mcp-client.sh`), state directory (`~/.mcp-communicator-telegram`), and reply-only question routing.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ How it works:
 
 This design eliminates the race condition that occurred when multiple Claude Code sessions competed for the Telegram bot polling lock.
 
+## Singleton invariant
+
+One daemon per bot token. Period.
+
+Detection must be ownership-agnostic: the daemon is a shared resource, and a different user is not a reason to start a second one. Any check that depends on who owns the process (e.g. `kill -0`) is fundamentally wrong.
+
 ## State Directory
 
 The daemon stores its runtime state in `/tmp/mcp-communicator-telegram-<token-hash>/`, where `<token-hash>` is the first 8 hex chars of `sha256(TELEGRAM_TOKEN)`. Keying by token (not by user) means any OS user pointing at a wrapper that resolves the same token reuses the same daemon — Telegram's `getUpdates` is mutually exclusive at the bot-token level, so per-user daemons would compete for the same poll and lose updates. Different bots get different hashes and run side by side.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This design eliminates the race condition that occurred when multiple Claude Cod
 
 ## State Directory
 
-The daemon stores its runtime state in `~/.mcp-communicator-telegram/`:
+The daemon stores its runtime state in `/tmp/mcp-communicator-telegram-$USER/`:
 
 | File | Purpose |
 |------|---------|
@@ -241,14 +241,14 @@ If the daemon gets into a bad state (e.g., port conflict, stale PID file, Telegr
 
 ```bash
 pkill -f 'node.*build/index.js'
-rm -rf ~/.mcp-communicator-telegram
+rm -rf /tmp/mcp-communicator-telegram-$USER
 ```
 
 The next MCP tool call from any Claude Code session will spawn a fresh daemon.
 
 Other common issues:
 
-- **Daemon not starting**: Check `~/.mcp-communicator-telegram/server.log` for error output.
+- **Daemon not starting**: Check `/tmp/mcp-communicator-telegram-$USER/server.log` for error output.
 - **Bot not responding to replies**: Ensure `CHAT_ID` in `.env` matches the chat where you are replying. The bot only accepts messages from the configured chat ID.
 - **Port range exhausted**: All ports 13579–13588 are in use. Either free a port or set `MCP_HTTP_PORT` to an available range start.
 
@@ -291,4 +291,4 @@ qpd-v
 
 ## Version
 
-0.3.0 — First release with the shared HTTP daemon, stdio wrapper (`bin/mcp-client.sh`), state directory (`~/.mcp-communicator-telegram`), and reply-only question routing.
+0.3.0 — First release with the shared HTTP daemon, stdio wrapper (`bin/mcp-client.sh`), state directory (`/tmp/mcp-communicator-telegram-$USER`), and reply-only question routing.

--- a/README.md
+++ b/README.md
@@ -302,3 +302,5 @@ qpd-v
 0.3.0 — First release with the shared HTTP daemon, stdio wrapper (`bin/mcp-client.sh`), per-user state directory, and reply-only question routing.
 
 0.3.1 — State directory keyed by `sha256(TELEGRAM_TOKEN)` only (no `$USER`), mode `2770` group `sudo`, so all sudo members sharing a token share one daemon instead of competing for Telegram's exclusive long poll.
+
+0.3.4 — Singleton detection uses `flock` (kernel-enforced, ownership-agnostic) instead of `kill -0`.

--- a/bin/mcp-client.sh
+++ b/bin/mcp-client.sh
@@ -47,9 +47,14 @@ ensure_daemon() {
   if ! (
     flock -x 200
 
-    if [[ -f "$PID_FILE" ]]; then
-      pid=$(cat "$PID_FILE")
-      if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    # Check whether a daemon is already listening on the port recorded
+    # in PORT_FILE.  An HTTP health check works cross-user, unlike
+    # kill -0 which fails when the daemon is owned by another user.
+    if [[ -f "$PORT_FILE" ]]; then
+      port=$(cat "$PORT_FILE")
+      if curl -sS --max-time 1 -X POST "http://127.0.0.1:$port/mcp" \
+          -H 'Content-Type: application/json' \
+          -d '{"jsonrpc":"2.0","method":"ping","id":"health"}' >/dev/null 2>&1; then
         exit 0   # daemon alive; nothing to do
       fi
       rm -f "$PID_FILE" "$PORT_FILE"
@@ -77,8 +82,9 @@ ensure_daemon() {
 }
 
 # Proxy newline-delimited JSON-RPC on stdin to the daemon over HTTP.
-# Re-resolve per request (ensure_daemon is a kill -0 in steady state) so the
-# session survives the daemon dying and being respawned on a new port.
+# Re-resolve per request (ensure_daemon pings the daemon via HTTP, which
+# works cross-user) so the session survives the daemon dying and being
+# respawned on a new port.
 while IFS= read -r line; do
   [[ -z "$line" ]] && continue
   ensure_daemon

--- a/bin/mcp-client.sh
+++ b/bin/mcp-client.sh
@@ -31,7 +31,10 @@ ensure_daemon() {
       rm -f "$PID_FILE" "$PORT_FILE"
     fi
 
-    nohup node "$DAEMON_BIN" >> "$LOG_FILE" 2>&1 &
+    # Close fd 200 for the daemon child. Otherwise it inherits the lock fd
+    # from our subshell and keeps flock held forever — a second wrapper's
+    # `flock -x 200` would then block indefinitely.
+    nohup node "$DAEMON_BIN" >> "$LOG_FILE" 2>&1 200>&- &
     disown
 
     # Wait up to 5s for the daemon to write its port file.

--- a/bin/mcp-client.sh
+++ b/bin/mcp-client.sh
@@ -55,13 +55,6 @@ ensure_daemon() {
       rm -f "$PID_FILE" "$PORT_FILE"
     fi
 
-    # Pre-spawn zombie sweep: any node still running this exact daemon binary
-    # is a leak from a prior spurious spawn (we wouldn't reach here if the
-    # PID-file-recorded daemon were alive). Restricted to our euid so
-    # cross-user processes silently no-op. Belt-and-suspenders for the case
-    # where PID file was lost (e.g. /tmp wipe) while the daemon kept polling.
-    pkill -u "$(id -u)" -TERM -f "$DAEMON_BIN" 2>/dev/null || true
-
     # Close fd 200 for the daemon child so it does not inherit the lock fd
     # from our subshell and keep flock held forever. Close stdin (</dev/null)
     # so the daemon is not pinned to our pipe if CC exits.
@@ -84,14 +77,12 @@ ensure_daemon() {
 }
 
 # Proxy newline-delimited JSON-RPC on stdin to the daemon over HTTP.
-# Re-resolve the daemon (ensure alive, re-read port) per request so a session
-# survives the daemon dying and being respawned on a new port by another
-# wrapper. ensure_daemon is a cheap kill -0 check in the steady state.
+# Re-resolve per request (ensure_daemon is a kill -0 in steady state) so the
+# session survives the daemon dying and being respawned on a new port.
 while IFS= read -r line; do
   [[ -z "$line" ]] && continue
   ensure_daemon
   PORT=$(cat "$PORT_FILE")
-  [[ -n "$PORT" ]] || { echo "[mcp-client] empty $PORT_FILE after spawn" >&2; continue; }
   reply=$(
     printf '%s' "$line" \
     | curl -sS -X POST "http://127.0.0.1:$PORT/mcp" \

--- a/bin/mcp-client.sh
+++ b/bin/mcp-client.sh
@@ -90,7 +90,7 @@ while IFS= read -r line; do
     | curl -sS -X POST "http://127.0.0.1:$PORT/mcp" \
         -H 'Content-Type: application/json' \
         --data-binary @- \
-        --max-time 0
+        --max-time 43200
   ) || {
     echo "[mcp-client] curl failed on request: $line" >&2
     continue

--- a/bin/mcp-client.sh
+++ b/bin/mcp-client.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# MCP stdio↔HTTP bridge: forwards one JSON-RPC message per line from stdin
+# to the shared Telegram MCP daemon and writes each response to stdout.
+# Lazily spawns the daemon if it is not running. Concurrent wrappers are
+# serialized through flock during the detect-and-spawn critical section
+# ONLY — the lock is released before the proxy loop starts so long-running
+# ask_user calls do not block a second wrapper from connecting.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DAEMON_BIN="$SCRIPT_DIR/../build/index.js"
+STATE_DIR="$HOME/.mcp-communicator-telegram"
+PID_FILE="$STATE_DIR/server.pid"
+PORT_FILE="$STATE_DIR/server.port"
+LOG_FILE="$STATE_DIR/server.log"
+LOCK_FILE="$STATE_DIR/spawn.lock"
+
+mkdir -p "$STATE_DIR"
+
+ensure_daemon() {
+  # Subshell scopes fd 200 (and therefore the flock) to the critical section.
+  # When the subshell exits, the lock releases automatically.
+  if ! (
+    flock -x 200
+
+    if [[ -f "$PID_FILE" ]]; then
+      pid=$(cat "$PID_FILE")
+      if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        exit 0   # daemon alive; nothing to do
+      fi
+      rm -f "$PID_FILE" "$PORT_FILE"
+    fi
+
+    nohup node "$DAEMON_BIN" >> "$LOG_FILE" 2>&1 &
+    disown
+
+    # Wait up to 5s for the daemon to write its port file.
+    for _ in $(seq 50); do
+      if [[ -f "$PORT_FILE" ]]; then
+        exit 0
+      fi
+      sleep 0.1
+    done
+
+    exit 1   # spawn timeout
+  ) 200>"$LOCK_FILE"; then
+    echo "[mcp-client] daemon failed to start; see $LOG_FILE" >&2
+    exit 1
+  fi
+}
+
+ensure_daemon
+PORT=$(cat "$PORT_FILE")
+
+# Proxy newline-delimited JSON-RPC on stdin to the daemon over HTTP.
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  reply=$(
+    printf '%s' "$line" \
+    | curl -sS -X POST "http://127.0.0.1:$PORT/mcp" \
+        -H 'Content-Type: application/json' \
+        --data-binary @- \
+        --max-time 0
+  ) || {
+    echo "[mcp-client] curl failed on request: $line" >&2
+    continue
+  }
+  # Empty reply means the request was a JSON-RPC notification — no response.
+  if [[ -n "$reply" ]]; then
+    printf '%s\n' "$reply"
+  fi
+done

--- a/bin/mcp-client.sh
+++ b/bin/mcp-client.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DAEMON_BIN="$SCRIPT_DIR/../build/index.js"
-STATE_DIR="$HOME/.mcp-communicator-telegram"
+STATE_DIR="/tmp/mcp-communicator-telegram-${USER:-$(id -un)}"
 PID_FILE="$STATE_DIR/server.pid"
 PORT_FILE="$STATE_DIR/server.port"
 LOG_FILE="$STATE_DIR/server.log"

--- a/bin/mcp-client.sh
+++ b/bin/mcp-client.sh
@@ -55,6 +55,13 @@ ensure_daemon() {
       rm -f "$PID_FILE" "$PORT_FILE"
     fi
 
+    # Pre-spawn zombie sweep: any node still running this exact daemon binary
+    # is a leak from a prior spurious spawn (we wouldn't reach here if the
+    # PID-file-recorded daemon were alive). Restricted to our euid so
+    # cross-user processes silently no-op. Belt-and-suspenders for the case
+    # where PID file was lost (e.g. /tmp wipe) while the daemon kept polling.
+    pkill -u "$(id -u)" -TERM -f "$DAEMON_BIN" 2>/dev/null || true
+
     # Close fd 200 for the daemon child so it does not inherit the lock fd
     # from our subshell and keep flock held forever. Close stdin (</dev/null)
     # so the daemon is not pinned to our pipe if CC exits.
@@ -76,13 +83,15 @@ ensure_daemon() {
   fi
 }
 
-ensure_daemon
-PORT=$(cat "$PORT_FILE")
-[[ -n "$PORT" ]] || { echo "[mcp-client] empty $PORT_FILE after spawn" >&2; exit 1; }
-
 # Proxy newline-delimited JSON-RPC on stdin to the daemon over HTTP.
+# Re-resolve the daemon (ensure alive, re-read port) per request so a session
+# survives the daemon dying and being respawned on a new port by another
+# wrapper. ensure_daemon is a cheap kill -0 check in the steady state.
 while IFS= read -r line; do
   [[ -z "$line" ]] && continue
+  ensure_daemon
+  PORT=$(cat "$PORT_FILE")
+  [[ -n "$PORT" ]] || { echo "[mcp-client] empty $PORT_FILE after spawn" >&2; continue; }
   reply=$(
     printf '%s' "$line" \
     | curl -sS -X POST "http://127.0.0.1:$PORT/mcp" \

--- a/bin/mcp-client.sh
+++ b/bin/mcp-client.sh
@@ -9,7 +9,21 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DAEMON_BIN="$SCRIPT_DIR/../build/index.js"
-STATE_DIR="/tmp/mcp-communicator-telegram-${USER:-$(id -un)}"
+ENV_FILE="$SCRIPT_DIR/../.env"
+
+# Match the daemon's STATE_DIR keying: sha256(TELEGRAM_TOKEN) suffix lets
+# different bots coexist and identical bots (any chat id) share one daemon.
+INSTANCE_HASH=$(
+  set -a
+  # shellcheck disable=SC1090
+  . "$ENV_FILE" >/dev/null 2>&1 || true
+  printf '%s' "${TELEGRAM_TOKEN:-}" | sha256sum | cut -c1-8
+)
+if [[ -z "$INSTANCE_HASH" || "$INSTANCE_HASH" == "$(printf '' | sha256sum | cut -c1-8)" ]]; then
+  echo "[mcp-client] TELEGRAM_TOKEN not found in $ENV_FILE" >&2
+  exit 1
+fi
+STATE_DIR="/tmp/mcp-communicator-telegram-${USER:-$(id -un)}-${INSTANCE_HASH}"
 PID_FILE="$STATE_DIR/server.pid"
 PORT_FILE="$STATE_DIR/server.port"
 LOG_FILE="$STATE_DIR/server.log"

--- a/bin/mcp-client.sh
+++ b/bin/mcp-client.sh
@@ -23,17 +23,23 @@ if [[ -z "$INSTANCE_HASH" || "$INSTANCE_HASH" == "$(printf '' | sha256sum | cut 
   echo "[mcp-client] TELEGRAM_TOKEN not found in $ENV_FILE" >&2
   exit 1
 fi
-STATE_DIR="/tmp/mcp-communicator-telegram-${USER:-$(id -un)}-${INSTANCE_HASH}"
+STATE_DIR="/tmp/mcp-communicator-telegram-${INSTANCE_HASH}"
 PID_FILE="$STATE_DIR/server.pid"
 PORT_FILE="$STATE_DIR/server.port"
 LOG_FILE="$STATE_DIR/server.log"
 LOCK_FILE="$STATE_DIR/spawn.lock"
 
-# 0o700 state dir: server.log contains Telegram question/answer bodies, so on
-# a multi-user host it must not be readable by peers. umask 077 also covers
-# any files the daemon writes (server.pid, server.port) with 0o600.
-umask 077
+# State dir keyed only by sha256(TELEGRAM_TOKEN) so any user with the same
+# token shares one daemon (Telegram's getUpdates is mutually exclusive at the
+# bot-token level — per-user dirs would cause two daemons to compete for the
+# same poll). Group=sudo + setgid (2770) so all sudo members can spawn /
+# inspect / clean the shared dir; files inherit gid=sudo via setgid and get
+# 0o660 from umask 007. server.log holds Q/A bodies — readable inside sudo
+# group, which on this box is the shared-credential trust boundary anyway.
+umask 007
 mkdir -p "$STATE_DIR"
+chgrp sudo "$STATE_DIR" 2>/dev/null || true
+chmod 2770 "$STATE_DIR" 2>/dev/null || true
 
 ensure_daemon() {
   # Subshell scopes fd 200 (and therefore the flock) to the critical section.

--- a/bin/mcp-client.sh
+++ b/bin/mcp-client.sh
@@ -47,23 +47,19 @@ ensure_daemon() {
   if ! (
     flock -x 200
 
-    # Check whether a daemon is already listening on the port recorded
-    # in PORT_FILE.  An HTTP health check works cross-user, unlike
-    # kill -0 which fails when the daemon is owned by another user.
-    if [[ -f "$PORT_FILE" ]]; then
-      port=$(cat "$PORT_FILE")
-      if curl -sS --max-time 1 -X POST "http://127.0.0.1:$port/mcp" \
-          -H 'Content-Type: application/json' \
-          -d '{"jsonrpc":"2.0","method":"ping","id":"health"}' >/dev/null 2>&1; then
-        exit 0   # daemon alive; nothing to do
-      fi
-      rm -f "$PID_FILE" "$PORT_FILE"
+    # The daemon holds an exclusive flock on PORT_FILE for life.
+    # If we can't acquire it non-blocking, the daemon is alive.
+    # This works cross-user because flock is kernel-enforced.
+    if ! flock -n "$PORT_FILE" -c "true" 2>/dev/null; then
+      exit 0   # daemon alive; nothing to do
     fi
+    # Lock is free — no daemon. Clean up stale files (if any).
+    rm -f "$PID_FILE" "$PORT_FILE"
 
     # Close fd 200 for the daemon child so it does not inherit the lock fd
     # from our subshell and keep flock held forever. Close stdin (</dev/null)
     # so the daemon is not pinned to our pipe if CC exits.
-    nohup node "$DAEMON_BIN" < /dev/null >> "$LOG_FILE" 2>&1 200>&- &
+    nohup flock -x "$PORT_FILE" node "$DAEMON_BIN" < /dev/null >> "$LOG_FILE" 2>&1 200>&- &
     disown
 
     # Wait up to 5s for the daemon to write its port file.
@@ -82,9 +78,9 @@ ensure_daemon() {
 }
 
 # Proxy newline-delimited JSON-RPC on stdin to the daemon over HTTP.
-# Re-resolve per request (ensure_daemon pings the daemon via HTTP, which
-# works cross-user) so the session survives the daemon dying and being
-# respawned on a new port.
+# Re-resolve per request (ensure_daemon checks the flock on server.port,
+# which works cross-user) so the session survives the daemon dying and
+# being respawned on a new port.
 while IFS= read -r line; do
   [[ -z "$line" ]] && continue
   ensure_daemon

--- a/bin/mcp-client.sh
+++ b/bin/mcp-client.sh
@@ -15,6 +15,10 @@ PORT_FILE="$STATE_DIR/server.port"
 LOG_FILE="$STATE_DIR/server.log"
 LOCK_FILE="$STATE_DIR/spawn.lock"
 
+# 0o700 state dir: server.log contains Telegram question/answer bodies, so on
+# a multi-user host it must not be readable by peers. umask 077 also covers
+# any files the daemon writes (server.pid, server.port) with 0o600.
+umask 077
 mkdir -p "$STATE_DIR"
 
 ensure_daemon() {
@@ -31,10 +35,10 @@ ensure_daemon() {
       rm -f "$PID_FILE" "$PORT_FILE"
     fi
 
-    # Close fd 200 for the daemon child. Otherwise it inherits the lock fd
-    # from our subshell and keeps flock held forever — a second wrapper's
-    # `flock -x 200` would then block indefinitely.
-    nohup node "$DAEMON_BIN" >> "$LOG_FILE" 2>&1 200>&- &
+    # Close fd 200 for the daemon child so it does not inherit the lock fd
+    # from our subshell and keep flock held forever. Close stdin (</dev/null)
+    # so the daemon is not pinned to our pipe if CC exits.
+    nohup node "$DAEMON_BIN" < /dev/null >> "$LOG_FILE" 2>&1 200>&- &
     disown
 
     # Wait up to 5s for the daemon to write its port file.

--- a/bin/mcp-client.sh
+++ b/bin/mcp-client.sh
@@ -36,7 +36,7 @@ ensure_daemon() {
 
     # Wait up to 5s for the daemon to write its port file.
     for _ in $(seq 50); do
-      if [[ -f "$PORT_FILE" ]]; then
+      if [[ -s "$PORT_FILE" ]]; then
         exit 0
       fi
       sleep 0.1
@@ -51,6 +51,7 @@ ensure_daemon() {
 
 ensure_daemon
 PORT=$(cat "$PORT_FILE")
+[[ -n "$PORT" ]] || { echo "[mcp-client] empty $PORT_FILE after spawn" >&2; exit 1; }
 
 # Proxy newline-delimited JSON-RPC on stdin to the daemon over HTTP.
 while IFS= read -r line; do

--- a/docs/superpowers/plans/2026-04-20-telegram-mcp-http-daemon.md
+++ b/docs/superpowers/plans/2026-04-20-telegram-mcp-http-daemon.md
@@ -747,7 +747,20 @@ count=$(pgrep -cf 'node.*build/index.js' || true)
 [[ "$count" -eq 1 ]] \
   && echo "PASS: exactly one daemon after concurrent spawn" \
   || { echo "FAIL: $count daemons after concurrent spawn"; pgrep -af 'node.*build/index.js'; exit 1; }
+
+# Also verify BOTH wrappers got a valid JSON-RPC response.
+# (The earlier counting-only check gave a false green when one wrapper was
+# silently blocked on flock and was SIGKILLed by `timeout 10` — it never
+# spawned a second daemon, so the count-based PASS lied. Always verify
+# both wrappers' stdout contains protocolVersion before declaring victory.)
+hit1=$(grep -c protocolVersion /tmp/wrap_race_1.out 2>/dev/null || echo 0)
+hit2=$(grep -c protocolVersion /tmp/wrap_race_2.out 2>/dev/null || echo 0)
+[[ "$hit1" -eq 1 && "$hit2" -eq 1 ]] \
+  || { echo "FAIL: wrapper responses missing (hit1=$hit1 hit2=$hit2)"; exit 1; }
 ```
+
+(To produce `/tmp/wrap_race_{1,2}.out`, redirect each wrapper's stdout
+inside the `for` loop: `... | timeout 10 "$WRAPPER" > "/tmp/wrap_race_$i.out" &`.)
 
 ```bash
 chmod +x /tmp/test-wrapper-race.sh

--- a/docs/superpowers/plans/2026-04-20-telegram-mcp-http-daemon.md
+++ b/docs/superpowers/plans/2026-04-20-telegram-mcp-http-daemon.md
@@ -1,0 +1,921 @@
+# Telegram MCP HTTP Daemon Refactor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the per-CC-session stdio MCP server with a shared HTTP daemon so multiple Claude Code windows can concurrently use the same Telegram bot without racing `getUpdates`.
+
+**Architecture:** Single long-lived daemon process (`build/index.js`) listens on a loopback HTTP port, owns the only Telegram polling connection, and writes PID/port to `~/.mcp-communicator-telegram/`. Each CC session spawns a thin bash wrapper (`bin/mcp-client.sh`) that ensures the daemon is alive, reads the port, and proxies stdio JSON-RPC traffic to the daemon over HTTP. `.mcp.json` points at the wrapper instead of `node build/index.js`.
+
+**Tech Stack:** Node.js/TypeScript (`node-telegram-bot-api`, built-in `http`, `dotenv`), bash (`flock`, `curl`). No new npm dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-http-daemon-design.md`
+
+**Starting state:** Branch `http-daemon` of `mcp-communicator-telegram`. `src/index.ts` has an **uncommitted WIP** that already converts the stdio transport to HTTP but does **not yet** do port scanning, state-file writing, state cleanup, or removal of the `lastQuestionId` fallback. Task 1 commits this WIP as a checkpoint; subsequent tasks add increments.
+
+---
+
+### Task 1: Commit the existing HTTP-skeleton WIP as a checkpoint
+
+**Files:**
+- Already modified (uncommitted): `src/index.ts`
+
+This captures the in-progress transport swap so every later task starts from a clean `git status`.
+
+- [ ] **Step 1: Verify WIP compiles**
+
+Run:
+```bash
+cd /home/youran/Abaqus2024/mcp-communicator-telegram
+npm run build
+```
+
+Expected: no output besides the tsc invocation line; exit 0.
+
+- [ ] **Step 2: Confirm the WIP state**
+
+Run:
+```bash
+git status
+git diff --stat
+```
+
+Expected: on branch `http-daemon`, one modified file `src/index.ts`, ~245 insertions / 303 deletions.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "Convert stdio MCP transport to HTTP skeleton
+
+Swap the hand-rolled stdio JSON-RPC handler for a Node http server on
+a fixed loopback port. No port scanning or state-file management yet;
+those arrive in follow-up commits. dotenv now reads .env via an
+explicit path so cwd no longer matters."
+```
+
+Expected: commit succeeds, `git status` clean.
+
+---
+
+### Task 2: Add port scanning and make the default port 13579
+
+**Files:**
+- Modify: `src/index.ts` (top-of-file constants + `startHttpServer`)
+
+**Current problem:** the daemon binds a fixed port. If it's occupied the daemon crashes with `EADDRINUSE`. The spec calls for scanning 13579–13588.
+
+- [ ] **Step 1: Write a failing check**
+
+This check will become part of the self-verification. Save as `/tmp/test-port-scan.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -e
+# Occupy the default port 13579
+nc -l 127.0.0.1 13579 >/dev/null &
+NC_PID=$!
+trap "kill $NC_PID 2>/dev/null; rm -rf ~/.mcp-communicator-telegram; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
+
+sleep 0.3
+
+# Start daemon; should pick 13580 because 13579 is taken
+cd /home/youran/Abaqus2024/mcp-communicator-telegram
+rm -rf ~/.mcp-communicator-telegram
+nohup node build/index.js > /tmp/daemon-test.log 2>&1 &
+sleep 2
+
+# Expected chosen port, printed in daemon log
+grep -q "listening on http://127.0.0.1:13580" /tmp/daemon-test.log \
+  && echo "PASS: daemon skipped 13579 and bound 13580" \
+  || { echo "FAIL: daemon did not skip the occupied port"; cat /tmp/daemon-test.log; exit 1; }
+```
+
+Make executable and run:
+```bash
+chmod +x /tmp/test-port-scan.sh
+/tmp/test-port-scan.sh
+```
+
+Expected: **FAIL** because the current code binds the fixed `HTTP_PORT` and errors out with `EADDRINUSE`.
+
+- [ ] **Step 2: Modify `src/index.ts`**
+
+Find this block near the top (around line 18):
+```typescript
+const HTTP_PORT = parseInt(process.env.MCP_HTTP_PORT ?? '8765', 10);
+const HTTP_HOST = process.env.MCP_HTTP_HOST ?? '127.0.0.1';
+```
+
+Replace with:
+```typescript
+const HTTP_PORT_START = parseInt(process.env.MCP_HTTP_PORT ?? '13579', 10);
+const HTTP_PORT_TRIES = 10;
+const HTTP_HOST = process.env.MCP_HTTP_HOST ?? '127.0.0.1';
+```
+
+Find the existing `startHttpServer` function (around line 403–459) and replace it **in its entirety** with the version below. The request-handling internals are unchanged; what changes is the return type (`Promise<{ server, port }>` instead of `http.Server`) and the port-scan loop that wraps `listen`:
+
+```typescript
+async function startHttpServer(): Promise<{ server: http.Server; port: number }> {
+  const server = http.createServer((req, res) => {
+    if (req.method !== 'POST' || !req.url?.startsWith('/mcp')) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('not found\n');
+      return;
+    }
+
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', async () => {
+      let request: any;
+      try {
+        request = JSON.parse(body);
+      } catch (error) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: -32700, message: 'Parse error' }
+        }));
+        return;
+      }
+
+      try {
+        const response = await dispatchRequest(request);
+        if (response === null) {
+          res.writeHead(202);
+          res.end();
+        } else {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(response));
+        }
+      } catch (error: any) {
+        console.error('Error handling request:', error);
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          jsonrpc: "2.0",
+          id: request?.id ?? null,
+          error: { code: -32000, message: error.message }
+        }));
+      }
+    });
+  });
+
+  server.requestTimeout = 0;
+  server.headersTimeout = 0;
+  server.keepAliveTimeout = 0;
+
+  for (let offset = 0; offset < HTTP_PORT_TRIES; offset++) {
+    const candidate = HTTP_PORT_START + offset;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (err: NodeJS.ErrnoException) => {
+          server.removeListener('listening', onListen);
+          reject(err);
+        };
+        const onListen = () => {
+          server.removeListener('error', onError);
+          resolve();
+        };
+        server.once('error', onError);
+        server.once('listening', onListen);
+        server.listen(candidate, HTTP_HOST);
+      });
+      console.error(`MCP HTTP server listening on http://${HTTP_HOST}:${candidate}/mcp`);
+      return { server, port: candidate };
+    } catch (err: any) {
+      if (err.code !== 'EADDRINUSE') throw err;
+      console.error(`Port ${candidate} in use, trying next`);
+    }
+  }
+
+  throw new Error(`No free port in range ${HTTP_PORT_START}-${HTTP_PORT_START + HTTP_PORT_TRIES - 1}`);
+}
+```
+
+Update `main()` (around line 470) to `await` the new async signature:
+```typescript
+async function main() {
+  const success = await initializeBot();
+  if (!success) {
+    console.error('Failed to initialize bot, exiting...');
+    process.exit(1);
+  }
+  await startHttpServer();
+}
+```
+
+- [ ] **Step 3: Rebuild and run the check**
+
+```bash
+npm run build
+/tmp/test-port-scan.sh
+```
+
+Expected: **PASS** (daemon skips 13579, binds 13580).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "Scan ports 13579-13588 when binding the HTTP server
+
+EADDRINUSE on the current candidate advances to the next; any other
+listen error is fatal. Default start port 13579 is outside the Linux
+ephemeral range and not a common service port. MCP_HTTP_PORT still
+overrides the start if set."
+```
+
+---
+
+### Task 3: Write state files after successful bind
+
+**Files:**
+- Modify: `src/index.ts` (imports, `main`, new helper)
+
+After the HTTP server binds, the daemon must advertise itself by writing `~/.mcp-communicator-telegram/server.pid` and `server.port` so the wrapper can find it.
+
+- [ ] **Step 1: Write a failing check**
+
+Save `/tmp/test-state-write.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -e
+trap "rm -rf ~/.mcp-communicator-telegram; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
+
+cd /home/youran/Abaqus2024/mcp-communicator-telegram
+rm -rf ~/.mcp-communicator-telegram
+nohup node build/index.js > /tmp/daemon-test.log 2>&1 &
+BG=$!
+sleep 2
+
+pid_file=~/.mcp-communicator-telegram/server.pid
+port_file=~/.mcp-communicator-telegram/server.port
+
+[[ -f "$pid_file" ]] || { echo "FAIL: no server.pid"; exit 1; }
+[[ -f "$port_file" ]] || { echo "FAIL: no server.port"; exit 1; }
+
+recorded_pid=$(cat "$pid_file")
+recorded_port=$(cat "$port_file")
+
+[[ "$recorded_pid" == "$BG" ]] || { echo "FAIL: pid mismatch ($recorded_pid vs $BG)"; exit 1; }
+[[ "$recorded_port" == "13579" ]] || { echo "FAIL: port unexpected ($recorded_port)"; exit 1; }
+
+echo "PASS: state files written with pid=$recorded_pid port=$recorded_port"
+```
+
+```bash
+chmod +x /tmp/test-state-write.sh
+/tmp/test-state-write.sh
+```
+
+Expected: **FAIL** ("no server.pid"), because no state writing exists yet.
+
+- [ ] **Step 2: Modify `src/index.ts`**
+
+Add a constant block near the other constants (after `HTTP_HOST`):
+```typescript
+import * as os from 'os';
+const STATE_DIR = path.join(os.homedir(), '.mcp-communicator-telegram');
+const PID_FILE = path.join(STATE_DIR, 'server.pid');
+const PORT_FILE = path.join(STATE_DIR, 'server.port');
+```
+
+(`os` needs a top-level `import`; place it next to the other imports.)
+
+Update `main()` to write the state files after bind:
+```typescript
+async function main() {
+  const success = await initializeBot();
+  if (!success) {
+    console.error('Failed to initialize bot, exiting...');
+    process.exit(1);
+  }
+  const { port } = await startHttpServer();
+
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  fs.writeFileSync(PID_FILE, `${process.pid}\n`);
+  fs.writeFileSync(PORT_FILE, `${port}\n`);
+  console.error(`State recorded: pid=${process.pid} port=${port} in ${STATE_DIR}`);
+}
+```
+
+- [ ] **Step 3: Rebuild and run the check**
+
+```bash
+npm run build
+/tmp/test-state-write.sh
+```
+
+Expected: **PASS**.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "Write server.pid and server.port after successful bind
+
+State dir is ~/.mcp-communicator-telegram, following the
+claude-memory-manager flat-single-value-file convention. These files
+let the wrapper script locate and health-check the daemon."
+```
+
+---
+
+### Task 4: Clean up state files on shutdown
+
+**Files:**
+- Modify: `src/index.ts` (shutdown handler + `process.on('exit')`)
+
+Currently, `SIGINT`/`SIGTERM` call `bot.stopPolling()` and `process.exit(0)` but leave stale state files behind. The wrapper's `kill -0 <pid>` probe will detect this and self-heal, but graceful shutdowns should leave no litter.
+
+- [ ] **Step 1: Write a failing check**
+
+Save `/tmp/test-state-cleanup.sh`:
+```bash
+#!/usr/bin/env bash
+set -e
+trap "rm -rf ~/.mcp-communicator-telegram; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
+
+cd /home/youran/Abaqus2024/mcp-communicator-telegram
+rm -rf ~/.mcp-communicator-telegram
+nohup node build/index.js > /tmp/daemon-test.log 2>&1 &
+BG=$!
+sleep 2
+
+[[ -f ~/.mcp-communicator-telegram/server.pid ]] || { echo "setup fail: no pid file"; exit 1; }
+
+kill -TERM "$BG"
+sleep 1
+
+[[ -f ~/.mcp-communicator-telegram/server.pid ]] \
+  && { echo "FAIL: server.pid survived SIGTERM"; exit 1; } \
+  || echo "server.pid cleaned"
+
+[[ -f ~/.mcp-communicator-telegram/server.port ]] \
+  && { echo "FAIL: server.port survived SIGTERM"; exit 1; } \
+  || echo "server.port cleaned"
+
+echo "PASS: graceful shutdown cleans up state files"
+```
+
+```bash
+chmod +x /tmp/test-state-cleanup.sh
+/tmp/test-state-cleanup.sh
+```
+
+Expected: **FAIL** ("server.pid survived SIGTERM").
+
+- [ ] **Step 2: Modify `src/index.ts`**
+
+Replace the existing `shutdown` block (around line 461):
+
+```typescript
+const cleanupState = () => {
+  try { fs.unlinkSync(PID_FILE); } catch {}
+  try { fs.unlinkSync(PORT_FILE); } catch {}
+};
+
+const shutdown = () => {
+  if (bot) {
+    bot.stopPolling();
+  }
+  cleanupState();
+  process.exit(0);
+};
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+process.on('exit', cleanupState);
+```
+
+The `process.on('exit')` handler is a synchronous safety net for uncaught exceptions so crashes don't leave stale state either. `fs.unlinkSync` is safe inside an `exit` handler.
+
+- [ ] **Step 3: Rebuild and run the check**
+
+```bash
+npm run build
+/tmp/test-state-cleanup.sh
+```
+
+Expected: **PASS**.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "Delete pid/port state files on graceful shutdown
+
+SIGINT/SIGTERM now clean up explicitly; process.on('exit') runs the
+same cleanup synchronously as a safety net for uncaught exceptions.
+Kill -9 still leaves stale files — the wrapper heals by probing the
+stale pid with kill -0."
+```
+
+---
+
+### Task 5: Remove the `lastQuestionId` plain-message fallback
+
+**Files:**
+- Modify: `src/index.ts` (imports around line 22 + message handler around line 59)
+
+Per the spec, plain Telegram messages (not sent via Reply) should no longer be routed to the most recent `ask_user`. They should be logged and discarded.
+
+- [ ] **Step 1: Write the failing check**
+
+Save `/tmp/test-plain-message.sh`. (This test uses direct Telegram API calls to simulate a plain message; it requires `TELEGRAM_TOKEN` and `CHAT_ID` loaded from the .env.)
+
+```bash
+#!/usr/bin/env bash
+set -e
+cd /home/youran/Abaqus2024/mcp-communicator-telegram
+source .env
+
+trap "rm -rf ~/.mcp-communicator-telegram; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
+
+rm -rf ~/.mcp-communicator-telegram
+nohup node build/index.js > /tmp/daemon-test.log 2>&1 &
+sleep 2
+
+PORT=$(cat ~/.mcp-communicator-telegram/server.port)
+
+# Fire ask_user in background (will block waiting for a reply)
+(curl -sS -X POST "http://127.0.0.1:$PORT/mcp" \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"ask_user","arguments":{"question":"test-plain-message"}}}' \
+  > /tmp/askuser-response.json) &
+
+sleep 3  # give Telegram a moment
+
+# Simulate a plain (non-Reply) message from the user
+curl -sS "https://api.telegram.org/bot$TELEGRAM_TOKEN/sendMessage" \
+  -d "chat_id=$CHAT_ID" \
+  -d "text=this is a plain message, should NOT resolve ask_user" > /dev/null
+
+sleep 3
+
+# If the old fallback still exists, ask_user resolved and askuser-response.json has content
+if [[ -s /tmp/askuser-response.json ]] && grep -q '"result"' /tmp/askuser-response.json; then
+  echo "FAIL: ask_user was resolved by a plain message"
+  cat /tmp/askuser-response.json
+  exit 1
+fi
+
+# Daemon log should record the rejection
+grep -q "No matching question found" /tmp/daemon-test.log \
+  && echo "PASS: plain message was ignored" \
+  || { echo "FAIL: daemon did not log the ignore"; tail -20 /tmp/daemon-test.log; exit 1; }
+```
+
+```bash
+chmod +x /tmp/test-plain-message.sh
+/tmp/test-plain-message.sh
+```
+
+Expected: **FAIL** ("ask_user was resolved by a plain message"), because the `lastQuestionId` fallback still routes plain messages.
+
+- [ ] **Step 2: Modify `src/index.ts`**
+
+Find the module-level declaration (around line 22):
+```typescript
+let lastQuestionId: string | null = null;
+```
+**Delete this line.**
+
+Find the `askUser` function's line that sets it (around where `lastQuestionId = questionId;` appears, after `const questionId = ...`):
+```typescript
+  lastQuestionId = questionId;
+```
+**Delete this line.**
+
+Find the message handler (around lines 59–61):
+```typescript
+      if (!questionId) {
+        questionId = lastQuestionId;
+      }
+```
+**Delete these three lines.**
+
+Also find the cleanup line inside the "Found matching question" branch (around line 70–71):
+```typescript
+        lastQuestionId = null;
+```
+**Delete this line.**
+
+Update the log line (around line 63) from:
+```typescript
+      console.error('Question ID (from reply or last):', questionId);
+```
+to:
+```typescript
+      console.error('Question ID (from Reply only):', questionId);
+```
+
+- [ ] **Step 3: Rebuild and run the check**
+
+```bash
+npm run build
+/tmp/test-plain-message.sh
+```
+
+Expected: **PASS** ("plain message was ignored").
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "Ignore plain Telegram messages; only explicit Replies are routed
+
+Remove the lastQuestionId fallback. With multiple concurrent CC
+sessions holding open ask_user promises on the same daemon, 'most
+recent question' is ambiguous and unsafe. The reply-to-message route
+with #<questionId> tag is the only resolution path now."
+```
+
+---
+
+### Task 6: Create `bin/mcp-client.sh` wrapper
+
+**Files:**
+- Create: `bin/mcp-client.sh`
+
+The wrapper is the only file CC's `.mcp.json` launches. It handles liveness detection, daemon spawn with flock, and stdio↔HTTP proxying.
+
+- [ ] **Step 1: Write a failing check**
+
+Save `/tmp/test-wrapper-basic.sh`:
+```bash
+#!/usr/bin/env bash
+set -e
+trap "rm -rf ~/.mcp-communicator-telegram; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
+
+rm -rf ~/.mcp-communicator-telegram
+pkill -f 'node.*build/index.js' 2>/dev/null || true
+
+WRAPPER=/home/youran/Abaqus2024/mcp-communicator-telegram/bin/mcp-client.sh
+[[ -x "$WRAPPER" ]] || { echo "FAIL: wrapper not present or not executable"; exit 1; }
+
+# Send a single initialize request, check for a well-formed JSON-RPC response
+reply=$(printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}' | timeout 10 "$WRAPPER")
+
+echo "$reply" | grep -q '"protocolVersion":"2024-11-05"' \
+  && echo "PASS: wrapper handshakes via stdio/HTTP proxy" \
+  || { echo "FAIL: unexpected reply"; echo "$reply"; exit 1; }
+```
+
+```bash
+chmod +x /tmp/test-wrapper-basic.sh
+/tmp/test-wrapper-basic.sh
+```
+
+Expected: **FAIL** ("wrapper not present or not executable").
+
+- [ ] **Step 2: Create `bin/mcp-client.sh`**
+
+Save exactly as written:
+
+```bash
+#!/usr/bin/env bash
+# MCP stdio↔HTTP bridge: forwards one JSON-RPC message per line from stdin
+# to the shared Telegram MCP daemon and writes each response to stdout.
+# Lazily spawns the daemon if it is not running. Concurrent wrappers are
+# serialized through flock during the detect-and-spawn critical section
+# ONLY — the lock is released before the proxy loop starts so long-running
+# ask_user calls do not block a second wrapper from connecting.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DAEMON_BIN="$SCRIPT_DIR/../build/index.js"
+STATE_DIR="$HOME/.mcp-communicator-telegram"
+PID_FILE="$STATE_DIR/server.pid"
+PORT_FILE="$STATE_DIR/server.port"
+LOG_FILE="$STATE_DIR/server.log"
+LOCK_FILE="$STATE_DIR/spawn.lock"
+
+mkdir -p "$STATE_DIR"
+
+ensure_daemon() {
+  # Subshell scopes fd 200 (and therefore the flock) to the critical section.
+  # When the subshell exits, the lock releases automatically.
+  if ! (
+    flock -x 200
+
+    if [[ -f "$PID_FILE" ]]; then
+      pid=$(cat "$PID_FILE")
+      if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        exit 0   # daemon alive; nothing to do
+      fi
+      rm -f "$PID_FILE" "$PORT_FILE"
+    fi
+
+    nohup node "$DAEMON_BIN" >> "$LOG_FILE" 2>&1 &
+    disown
+
+    # Wait up to 5s for the daemon to write its port file.
+    for _ in $(seq 50); do
+      if [[ -f "$PORT_FILE" ]]; then
+        exit 0
+      fi
+      sleep 0.1
+    done
+
+    exit 1   # spawn timeout
+  ) 200>"$LOCK_FILE"; then
+    echo "[mcp-client] daemon failed to start; see $LOG_FILE" >&2
+    exit 1
+  fi
+}
+
+ensure_daemon
+PORT=$(cat "$PORT_FILE")
+
+# Proxy newline-delimited JSON-RPC on stdin to the daemon over HTTP.
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  reply=$(
+    printf '%s' "$line" \
+    | curl -sS -X POST "http://127.0.0.1:$PORT/mcp" \
+        -H 'Content-Type: application/json' \
+        --data-binary @- \
+        --max-time 0
+  ) || {
+    echo "[mcp-client] curl failed on request: $line" >&2
+    continue
+  }
+  # Empty reply means the request was a JSON-RPC notification — no response.
+  if [[ -n "$reply" ]]; then
+    printf '%s\n' "$reply"
+  fi
+done
+```
+
+Then make it executable:
+```bash
+chmod +x bin/mcp-client.sh
+```
+
+- [ ] **Step 3: Run the check**
+
+```bash
+/tmp/test-wrapper-basic.sh
+```
+
+Expected: **PASS** ("wrapper handshakes via stdio/HTTP proxy").
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bin/mcp-client.sh
+git commit -m "Add bin/mcp-client.sh: stdio-HTTP bridge with lazy daemon spawn
+
+Each CC session spawns one wrapper. The wrapper acquires an exclusive
+flock on spawn.lock, probes the daemon via kill -0 on server.pid,
+respawns if dead, then proxies newline-delimited JSON-RPC from stdin
+over HTTP to the daemon."
+```
+
+---
+
+### Task 7: Verify wrapper self-heals after daemon death
+
+**Files:** no code changes — this is a verification task confirming the behavior built in Tasks 2–6.
+
+- [ ] **Step 1: Run the self-heal check**
+
+Save `/tmp/test-wrapper-selfheal.sh`:
+```bash
+#!/usr/bin/env bash
+set -e
+trap "rm -rf ~/.mcp-communicator-telegram; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
+
+WRAPPER=/home/youran/Abaqus2024/mcp-communicator-telegram/bin/mcp-client.sh
+
+rm -rf ~/.mcp-communicator-telegram
+pkill -f 'node.*build/index.js' 2>/dev/null || true
+
+# First run spawns a fresh daemon
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}' \
+  | timeout 10 "$WRAPPER" > /dev/null
+first_pid=$(cat ~/.mcp-communicator-telegram/server.pid)
+echo "First daemon pid: $first_pid"
+
+# Nuke it
+kill -9 "$first_pid"
+sleep 0.5
+
+# Second run should detect the dead pid, clean state, and respawn
+printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}' \
+  | timeout 10 "$WRAPPER" > /dev/null
+second_pid=$(cat ~/.mcp-communicator-telegram/server.pid)
+echo "Second daemon pid: $second_pid"
+
+[[ "$first_pid" != "$second_pid" ]] \
+  && kill -0 "$second_pid" 2>/dev/null \
+  && echo "PASS: wrapper respawned a fresh daemon" \
+  || { echo "FAIL: no fresh daemon"; exit 1; }
+```
+
+```bash
+chmod +x /tmp/test-wrapper-selfheal.sh
+/tmp/test-wrapper-selfheal.sh
+```
+
+Expected: **PASS** ("wrapper respawned a fresh daemon").
+
+- [ ] **Step 2: Run the spawn-race check**
+
+Save `/tmp/test-wrapper-race.sh`:
+```bash
+#!/usr/bin/env bash
+set -e
+trap "rm -rf ~/.mcp-communicator-telegram; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
+
+WRAPPER=/home/youran/Abaqus2024/mcp-communicator-telegram/bin/mcp-client.sh
+
+rm -rf ~/.mcp-communicator-telegram
+pkill -f 'node.*build/index.js' 2>/dev/null || true
+
+# Fire two wrappers at essentially the same time
+for i in 1 2; do
+  printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}' \
+    | timeout 10 "$WRAPPER" > /dev/null &
+done
+wait
+
+count=$(pgrep -cf 'node.*build/index.js' || true)
+[[ "$count" -eq 1 ]] \
+  && echo "PASS: exactly one daemon after concurrent spawn" \
+  || { echo "FAIL: $count daemons after concurrent spawn"; pgrep -af 'node.*build/index.js'; exit 1; }
+```
+
+```bash
+chmod +x /tmp/test-wrapper-race.sh
+/tmp/test-wrapper-race.sh
+```
+
+Expected: **PASS** ("exactly one daemon after concurrent spawn").
+
+- [ ] **Step 3: No commit needed** — verification only. If either check failed, revisit Task 6.
+
+---
+
+### Task 8: Point `.mcp.json` at the wrapper
+
+**Files:**
+- Modify: `/home/youran/Abaqus2024/.mcp.json`
+
+This is the final production cutover. The existing `.mcp.json` from the earlier partial refactor still points at HTTP-mode directly; revert it to stdio-with-wrapper.
+
+- [ ] **Step 1: Stop any running daemon and clear state**
+
+```bash
+pkill -f 'node.*build/index.js' 2>/dev/null || true
+rm -rf ~/.mcp-communicator-telegram
+```
+
+- [ ] **Step 2: Overwrite `/home/youran/Abaqus2024/.mcp.json`**
+
+Replace the file contents with exactly:
+
+```json
+{
+  "mcpServers": {
+    "mcp-communicator-telegram": {
+      "type": "stdio",
+      "command": "/home/youran/Abaqus2024/mcp-communicator-telegram/bin/mcp-client.sh"
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Verify via a fresh wrapper invocation**
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}' \
+  | /home/youran/Abaqus2024/mcp-communicator-telegram/bin/mcp-client.sh
+```
+
+Expected output: single JSON line containing `"protocolVersion":"2024-11-05"` and `"serverInfo":{"name":"mcp-communicator-telegram"`. The daemon starts automatically; `pgrep -f 'node.*build/index.js'` shows one process.
+
+- [ ] **Step 4: (Abaqus2024 is not a git repo — no commit here.) Note that the wrapper repo still has no change in this step.**
+
+---
+
+### Task 9: Bump version and update `README.md`
+
+**Files:**
+- Modify: `package.json`
+- Modify: `README.md`
+
+- [ ] **Step 1: Bump `package.json` version**
+
+Change:
+```json
+  "version": "0.2.1",
+```
+to:
+```json
+  "version": "0.3.0",
+```
+
+- [ ] **Step 2: Update `README.md`**
+
+Read `README.md` first to see the current structure, then rewrite the installation / configuration / troubleshooting sections. Keep these points:
+
+- This server now runs as a singleton HTTP daemon, lazily spawned by `bin/mcp-client.sh`.
+- State lives in `~/.mcp-communicator-telegram/`: `server.pid`, `server.port`, `server.log`.
+- Default port is 13579, scanning up to 13588 on conflict. Override with `MCP_HTTP_PORT`.
+- `.mcp.json` entry is stdio pointing at `bin/mcp-client.sh` (example given).
+- To reset: `pkill -f 'node.*build/index.js' ; rm -rf ~/.mcp-communicator-telegram`.
+- Only Telegram messages sent via **Reply** resolve pending `ask_user` questions; plain messages are ignored.
+
+Keep existing sections about `get-chat-id.js`, `.env` setup, and tool descriptions.
+
+- [ ] **Step 3: Build to confirm package.json is still valid**
+
+```bash
+npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json README.md
+git commit -m "Bump to 0.3.0 and document the HTTP daemon architecture
+
+0.3.0 is the first release with the shared HTTP daemon, stdio wrapper,
+state dir ~/.mcp-communicator-telegram, and reply-only question
+routing. README covers the new topology, default port range, and
+troubleshooting/reset procedure."
+```
+
+---
+
+### Task 10: End-to-end acceptance — multi-CC concurrent `ask_user`
+
+**Files:** no code changes — this is the manual acceptance test from the spec.
+
+Requires a human in the loop for the Telegram side. Cannot be fully automated.
+
+- [ ] **Step 1: Clean slate**
+
+```bash
+pkill -f 'node.*build/index.js' 2>/dev/null || true
+rm -rf ~/.mcp-communicator-telegram
+rm -f /tmp/daemon-test.log
+```
+
+- [ ] **Step 2: Open two CC sessions**
+
+Open two terminals. In each, run:
+```bash
+cd /home/youran/Abaqus2024
+claude --plugin-dir ../geo-lab
+```
+In each, start the supervisor flow: `/supervisor`.
+
+- [ ] **Step 3: In each session, invoke `ask_user`**
+
+Ask each supervisor session to send a different `ask_user` question via Telegram. Observe: both questions arrive in Telegram.
+
+- [ ] **Step 4: Reply to each question using Telegram's Reply feature**
+
+For each question message, tap **Reply** in Telegram and send a distinct answer.
+
+- [ ] **Step 5: Confirm both CC sessions received their matching reply**
+
+Each CC session's `ask_user` tool call should return the answer sent in response to ITS question, not the other's.
+
+- [ ] **Step 6: Negative check — plain message is ignored**
+
+While a fresh `ask_user` is pending, send a plain (non-Reply) message in the chat. The pending `ask_user` should **not** resolve. Daemon log (`~/.mcp-communicator-telegram/server.log`) should contain "No matching question found".
+
+- [ ] **Step 7: Wrap up**
+
+If all checks pass:
+```bash
+cd /home/youran/Abaqus2024/mcp-communicator-telegram
+git log --oneline -n 10   # review the 8 new commits on http-daemon
+```
+
+Final state: branch `http-daemon` contains (in order): WIP checkpoint, port scan, state write, state cleanup, reply-only routing, wrapper script, version bump + README. `Abaqus2024/.mcp.json` points at the wrapper. Two CC sessions can share one Telegram bot without racing.
+
+Merging `http-daemon` → `main` in the MCP repo is the user's call, not part of this plan.
+
+---
+
+## Verification Summary
+
+| Spec check | Covered by | Automated? |
+|---|---|---|
+| §Verification 1 — handshake | Task 6 step 3 | ✅ `/tmp/test-wrapper-basic.sh` |
+| §Verification 2 — port conflict | Task 2 step 3 | ✅ `/tmp/test-port-scan.sh` |
+| §Verification 3 — self-heal | Task 7 step 1 | ✅ `/tmp/test-wrapper-selfheal.sh` |
+| §Verification 4 — spawn race | Task 7 step 2 | ✅ `/tmp/test-wrapper-race.sh` |
+| §Verification 5 — multi-CC acceptance | Task 10 | ⚠️ Manual (human Telegram reply needed) |
+| §Verification 6 — plain-message regression | Task 5 step 3, Task 10 step 6 | ✅ `/tmp/test-plain-message.sh` + manual |
+
+Six of the spec's verification items become automated bash scripts; the final end-to-end acceptance needs a human because Telegram interaction is involved.

--- a/docs/superpowers/plans/2026-04-20-telegram-mcp-http-daemon.md
+++ b/docs/superpowers/plans/2026-04-20-telegram-mcp-http-daemon.md
@@ -4,7 +4,7 @@
 
 **Goal:** Replace the per-CC-session stdio MCP server with a shared HTTP daemon so multiple Claude Code windows can concurrently use the same Telegram bot without racing `getUpdates`.
 
-**Architecture:** Single long-lived daemon process (`build/index.js`) listens on a loopback HTTP port, owns the only Telegram polling connection, and writes PID/port to `~/.mcp-communicator-telegram/`. Each CC session spawns a thin bash wrapper (`bin/mcp-client.sh`) that ensures the daemon is alive, reads the port, and proxies stdio JSON-RPC traffic to the daemon over HTTP. `.mcp.json` points at the wrapper instead of `node build/index.js`.
+**Architecture:** Single long-lived daemon process (`build/index.js`) listens on a loopback HTTP port, owns the only Telegram polling connection, and writes PID/port to `/tmp/mcp-communicator-telegram-$USER/`. Each CC session spawns a thin bash wrapper (`bin/mcp-client.sh`) that ensures the daemon is alive, reads the port, and proxies stdio JSON-RPC traffic to the daemon over HTTP. `.mcp.json` points at the wrapper instead of `node build/index.js`.
 
 **Tech Stack:** Node.js/TypeScript (`node-telegram-bot-api`, built-in `http`, `dotenv`), bash (`flock`, `curl`). No new npm dependencies.
 
@@ -74,13 +74,13 @@ set -e
 # Occupy the default port 13579
 nc -l 127.0.0.1 13579 >/dev/null &
 NC_PID=$!
-trap "kill $NC_PID 2>/dev/null; rm -rf ~/.mcp-communicator-telegram; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
+trap "kill $NC_PID 2>/dev/null; rm -rf /tmp/mcp-communicator-telegram-$USER; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
 
 sleep 0.3
 
 # Start daemon; should pick 13580 because 13579 is taken
 cd /home/youran/Abaqus2024/mcp-communicator-telegram
-rm -rf ~/.mcp-communicator-telegram
+rm -rf /tmp/mcp-communicator-telegram-$USER
 nohup node build/index.js > /tmp/daemon-test.log 2>&1 &
 sleep 2
 
@@ -234,7 +234,7 @@ overrides the start if set."
 **Files:**
 - Modify: `src/index.ts` (imports, `main`, new helper)
 
-After the HTTP server binds, the daemon must advertise itself by writing `~/.mcp-communicator-telegram/server.pid` and `server.port` so the wrapper can find it.
+After the HTTP server binds, the daemon must advertise itself by writing `/tmp/mcp-communicator-telegram-$USER/server.pid` and `server.port` so the wrapper can find it.
 
 - [ ] **Step 1: Write a failing check**
 
@@ -243,16 +243,16 @@ Save `/tmp/test-state-write.sh`:
 ```bash
 #!/usr/bin/env bash
 set -e
-trap "rm -rf ~/.mcp-communicator-telegram; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
+trap "rm -rf /tmp/mcp-communicator-telegram-$USER; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
 
 cd /home/youran/Abaqus2024/mcp-communicator-telegram
-rm -rf ~/.mcp-communicator-telegram
+rm -rf /tmp/mcp-communicator-telegram-$USER
 nohup node build/index.js > /tmp/daemon-test.log 2>&1 &
 BG=$!
 sleep 2
 
-pid_file=~/.mcp-communicator-telegram/server.pid
-port_file=~/.mcp-communicator-telegram/server.port
+pid_file=/tmp/mcp-communicator-telegram-$USER/server.pid
+port_file=/tmp/mcp-communicator-telegram-$USER/server.port
 
 [[ -f "$pid_file" ]] || { echo "FAIL: no server.pid"; exit 1; }
 [[ -f "$port_file" ]] || { echo "FAIL: no server.port"; exit 1; }
@@ -278,7 +278,7 @@ Expected: **FAIL** ("no server.pid"), because no state writing exists yet.
 Add a constant block near the other constants (after `HTTP_HOST`):
 ```typescript
 import * as os from 'os';
-const STATE_DIR = path.join(os.homedir(), '.mcp-communicator-telegram');
+const STATE_DIR = path.join('/tmp', `mcp-communicator-telegram-${os.userInfo().username}`);
 const PID_FILE = path.join(STATE_DIR, 'server.pid');
 const PORT_FILE = path.join(STATE_DIR, 'server.port');
 ```
@@ -317,7 +317,7 @@ Expected: **PASS**.
 git add src/index.ts
 git commit -m "Write server.pid and server.port after successful bind
 
-State dir is ~/.mcp-communicator-telegram, following the
+State dir is /tmp/mcp-communicator-telegram-$USER, following the
 claude-memory-manager flat-single-value-file convention. These files
 let the wrapper script locate and health-check the daemon."
 ```
@@ -337,24 +337,24 @@ Save `/tmp/test-state-cleanup.sh`:
 ```bash
 #!/usr/bin/env bash
 set -e
-trap "rm -rf ~/.mcp-communicator-telegram; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
+trap "rm -rf /tmp/mcp-communicator-telegram-$USER; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
 
 cd /home/youran/Abaqus2024/mcp-communicator-telegram
-rm -rf ~/.mcp-communicator-telegram
+rm -rf /tmp/mcp-communicator-telegram-$USER
 nohup node build/index.js > /tmp/daemon-test.log 2>&1 &
 BG=$!
 sleep 2
 
-[[ -f ~/.mcp-communicator-telegram/server.pid ]] || { echo "setup fail: no pid file"; exit 1; }
+[[ -f /tmp/mcp-communicator-telegram-$USER/server.pid ]] || { echo "setup fail: no pid file"; exit 1; }
 
 kill -TERM "$BG"
 sleep 1
 
-[[ -f ~/.mcp-communicator-telegram/server.pid ]] \
+[[ -f /tmp/mcp-communicator-telegram-$USER/server.pid ]] \
   && { echo "FAIL: server.pid survived SIGTERM"; exit 1; } \
   || echo "server.pid cleaned"
 
-[[ -f ~/.mcp-communicator-telegram/server.port ]] \
+[[ -f /tmp/mcp-communicator-telegram-$USER/server.port ]] \
   && { echo "FAIL: server.port survived SIGTERM"; exit 1; } \
   || echo "server.port cleaned"
 
@@ -432,13 +432,13 @@ set -e
 cd /home/youran/Abaqus2024/mcp-communicator-telegram
 source .env
 
-trap "rm -rf ~/.mcp-communicator-telegram; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
+trap "rm -rf /tmp/mcp-communicator-telegram-$USER; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
 
-rm -rf ~/.mcp-communicator-telegram
+rm -rf /tmp/mcp-communicator-telegram-$USER
 nohup node build/index.js > /tmp/daemon-test.log 2>&1 &
 sleep 2
 
-PORT=$(cat ~/.mcp-communicator-telegram/server.port)
+PORT=$(cat /tmp/mcp-communicator-telegram-$USER/server.port)
 
 # Fire ask_user in background (will block waiting for a reply)
 (curl -sS -X POST "http://127.0.0.1:$PORT/mcp" \
@@ -548,9 +548,9 @@ Save `/tmp/test-wrapper-basic.sh`:
 ```bash
 #!/usr/bin/env bash
 set -e
-trap "rm -rf ~/.mcp-communicator-telegram; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
+trap "rm -rf /tmp/mcp-communicator-telegram-$USER; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
 
-rm -rf ~/.mcp-communicator-telegram
+rm -rf /tmp/mcp-communicator-telegram-$USER
 pkill -f 'node.*build/index.js' 2>/dev/null || true
 
 WRAPPER=/home/youran/Abaqus2024/mcp-communicator-telegram/bin/mcp-client.sh
@@ -587,7 +587,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DAEMON_BIN="$SCRIPT_DIR/../build/index.js"
-STATE_DIR="$HOME/.mcp-communicator-telegram"
+STATE_DIR="/tmp/mcp-communicator-telegram-${USER:-$(id -un)}"
 PID_FILE="$STATE_DIR/server.pid"
 PORT_FILE="$STATE_DIR/server.port"
 LOG_FILE="$STATE_DIR/server.log"
@@ -687,17 +687,17 @@ Save `/tmp/test-wrapper-selfheal.sh`:
 ```bash
 #!/usr/bin/env bash
 set -e
-trap "rm -rf ~/.mcp-communicator-telegram; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
+trap "rm -rf /tmp/mcp-communicator-telegram-$USER; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
 
 WRAPPER=/home/youran/Abaqus2024/mcp-communicator-telegram/bin/mcp-client.sh
 
-rm -rf ~/.mcp-communicator-telegram
+rm -rf /tmp/mcp-communicator-telegram-$USER
 pkill -f 'node.*build/index.js' 2>/dev/null || true
 
 # First run spawns a fresh daemon
 printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}' \
   | timeout 10 "$WRAPPER" > /dev/null
-first_pid=$(cat ~/.mcp-communicator-telegram/server.pid)
+first_pid=$(cat /tmp/mcp-communicator-telegram-$USER/server.pid)
 echo "First daemon pid: $first_pid"
 
 # Nuke it
@@ -707,7 +707,7 @@ sleep 0.5
 # Second run should detect the dead pid, clean state, and respawn
 printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{}}}' \
   | timeout 10 "$WRAPPER" > /dev/null
-second_pid=$(cat ~/.mcp-communicator-telegram/server.pid)
+second_pid=$(cat /tmp/mcp-communicator-telegram-$USER/server.pid)
 echo "Second daemon pid: $second_pid"
 
 [[ "$first_pid" != "$second_pid" ]] \
@@ -729,11 +729,11 @@ Save `/tmp/test-wrapper-race.sh`:
 ```bash
 #!/usr/bin/env bash
 set -e
-trap "rm -rf ~/.mcp-communicator-telegram; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
+trap "rm -rf /tmp/mcp-communicator-telegram-$USER; pkill -f 'node.*build/index.js' 2>/dev/null; exit" EXIT
 
 WRAPPER=/home/youran/Abaqus2024/mcp-communicator-telegram/bin/mcp-client.sh
 
-rm -rf ~/.mcp-communicator-telegram
+rm -rf /tmp/mcp-communicator-telegram-$USER
 pkill -f 'node.*build/index.js' 2>/dev/null || true
 
 # Fire two wrappers at essentially the same time
@@ -771,7 +771,7 @@ This is the final production cutover. The existing `.mcp.json` from the earlier 
 
 ```bash
 pkill -f 'node.*build/index.js' 2>/dev/null || true
-rm -rf ~/.mcp-communicator-telegram
+rm -rf /tmp/mcp-communicator-telegram-$USER
 ```
 
 - [ ] **Step 2: Overwrite `/home/youran/Abaqus2024/.mcp.json`**
@@ -824,10 +824,10 @@ to:
 Read `README.md` first to see the current structure, then rewrite the installation / configuration / troubleshooting sections. Keep these points:
 
 - This server now runs as a singleton HTTP daemon, lazily spawned by `bin/mcp-client.sh`.
-- State lives in `~/.mcp-communicator-telegram/`: `server.pid`, `server.port`, `server.log`.
+- State lives in `/tmp/mcp-communicator-telegram-$USER/`: `server.pid`, `server.port`, `server.log`.
 - Default port is 13579, scanning up to 13588 on conflict. Override with `MCP_HTTP_PORT`.
 - `.mcp.json` entry is stdio pointing at `bin/mcp-client.sh` (example given).
-- To reset: `pkill -f 'node.*build/index.js' ; rm -rf ~/.mcp-communicator-telegram`.
+- To reset: `pkill -f 'node.*build/index.js' ; rm -rf /tmp/mcp-communicator-telegram-$USER`.
 - Only Telegram messages sent via **Reply** resolve pending `ask_user` questions; plain messages are ignored.
 
 Keep existing sections about `get-chat-id.js`, `.env` setup, and tool descriptions.
@@ -847,7 +847,7 @@ git add package.json README.md
 git commit -m "Bump to 0.3.0 and document the HTTP daemon architecture
 
 0.3.0 is the first release with the shared HTTP daemon, stdio wrapper,
-state dir ~/.mcp-communicator-telegram, and reply-only question
+state dir /tmp/mcp-communicator-telegram-$USER, and reply-only question
 routing. README covers the new topology, default port range, and
 troubleshooting/reset procedure."
 ```
@@ -864,7 +864,7 @@ Requires a human in the loop for the Telegram side. Cannot be fully automated.
 
 ```bash
 pkill -f 'node.*build/index.js' 2>/dev/null || true
-rm -rf ~/.mcp-communicator-telegram
+rm -rf /tmp/mcp-communicator-telegram-$USER
 rm -f /tmp/daemon-test.log
 ```
 
@@ -891,7 +891,7 @@ Each CC session's `ask_user` tool call should return the answer sent in response
 
 - [ ] **Step 6: Negative check — plain message is ignored**
 
-While a fresh `ask_user` is pending, send a plain (non-Reply) message in the chat. The pending `ask_user` should **not** resolve. Daemon log (`~/.mcp-communicator-telegram/server.log`) should contain "No matching question found".
+While a fresh `ask_user` is pending, send a plain (non-Reply) message in the chat. The pending `ask_user` should **not** resolve. Daemon log (`/tmp/mcp-communicator-telegram-$USER/server.log`) should contain "No matching question found".
 
 - [ ] **Step 7: Wrap up**
 

--- a/docs/superpowers/specs/2026-04-20-http-daemon-design.md
+++ b/docs/superpowers/specs/2026-04-20-http-daemon-design.md
@@ -124,6 +124,21 @@ Two wrappers starting simultaneously: only one enters the critical section
 and may spawn; the other blocks on the lock and then sees the freshly-written
 `PORT_FILE` when it gets the lock, proceeding to connect without spawning.
 
+**Gotcha — fd inheritance must not leak the lock to the daemon.** `flock` is
+per-open-file-description, not per-process. A `fork` child inherits the
+parent's fd, sharing the same OFD and therefore co-holding the lock. The
+spawn line must explicitly close fd 200 (and stdin) on the daemon child:
+
+```bash
+nohup node "$DAEMON_BIN" < /dev/null >> "$LOG_FILE" 2>&1 200>&- &
+```
+
+Without `200>&-`, the daemon process keeps fd 200 open for its entire
+lifetime, the OFD's reference count never drops to zero, and the exclusive
+flock is never released. Every subsequent wrapper's `flock -x 200` then
+blocks forever (`wchan = locks_lock_inode_wait`). This was a real bug
+caught only during multi-CC acceptance — see commit `9a61e2d`.
+
 ## Lifecycle
 
 ### Daemon startup

--- a/docs/superpowers/specs/2026-04-20-http-daemon-design.md
+++ b/docs/superpowers/specs/2026-04-20-http-daemon-design.md
@@ -1,0 +1,250 @@
+# `mcp-communicator-telegram` HTTP Daemon Refactor — Design
+
+**Date**: 2026-04-20
+**Status**: Approved — ready for implementation planning
+**Target branch**: `http-daemon`
+
+## Problem
+
+The current stdio MCP server is spawned fresh by every Claude Code session that
+loads the project's `.mcp.json`. Each spawn opens its own Telegram bot polling
+connection via `node-telegram-bot-api` with `polling: true`. Telegram's Bot API
+allows only **one concurrent `getUpdates` request per bot token** — the
+first-arriving poller locks the bot; subsequent processes get
+`409 Conflict: terminated by other getUpdates request` and are permanently
+shut out by exponential-backoff retries that always lose to the incumbent.
+
+Observed effect: opening two CC sessions in `/home/youran/Abaqus2024/` produces
+deterministic behavior where the first-started session can `ask_user` and
+receive replies, and every subsequent session is unable to receive anything.
+Stale orphan MCP subprocesses (the server does not exit when its stdio pipe
+closes) compound this — one orphan left over from an earlier CC session can
+monopolize the bot for hours.
+
+Goal: run a **single** long-lived MCP server process (the "daemon") that owns
+the sole polling connection, and let every CC session connect to it as an
+HTTP client. Multiple CC windows must be usable concurrently.
+
+## Non-Goals
+
+- Multi-project isolation. The daemon is a machine-wide singleton that serves
+  one bot/chat (defined in `mcp-communicator-telegram/.env`). Projects using
+  different bots are out of scope.
+- HTTP-layer authentication. Loopback-only binding is the sole defense.
+- Automatic daemon restart on crash (beyond the wrapper's lazy respawn on next
+  demand).
+- SSE push / server-initiated notifications. The server only answers
+  client-initiated JSON-RPC requests.
+
+## Architecture
+
+```
+┌──────────────┐   stdio JSON-RPC   ┌─────────────────────┐
+│ CC session A │ ────────────────▶  │  bin/mcp-client.sh  │
+│              │ ◀────────────────  │  (bash, ~50 lines)  │
+└──────────────┘                    │                     │
+                                    │ 1. flock            │
+┌──────────────┐   stdio JSON-RPC   │ 2. check server.pid │
+│ CC session B │ ────────────────▶  │ 3. spawn if dead    │
+│              │ ◀────────────────  │ 4. read server.port │
+└──────────────┘                    │ 5. proxy via curl   │
+                                    └──────────┬──────────┘
+                                               │ HTTP POST
+                                               ▼
+                                    ┌──────────────────────┐
+                                    │ build/index.js       │
+                                    │ (daemon, singleton)  │
+                                    │ 127.0.0.1:<port>     │
+                                    │ Owns the single      │
+                                    │ Telegram poll loop   │
+                                    └──────────────────────┘
+```
+
+Each CC session still spawns its own stdio wrapper (that is how stdio MCP
+servers work). But every wrapper is a thin bash proxy that forwards JSON-RPC
+messages over HTTP to the one shared daemon. The daemon owns the Telegram bot
+state.
+
+Lazy daemon startup: the wrapper only ensures the daemon is alive. No systemd
+unit, no always-on process — the first CC session to call a Telegram tool
+incurs a ~few-hundred-millisecond startup; subsequent sessions find the
+daemon already alive.
+
+## State Layout
+
+Following the `claude-memory-manager` convention — flat single-value files in
+a home dot-dir named after the service:
+
+```
+~/.mcp-communicator-telegram/
+├── server.pid        # daemon PID (one integer)
+├── server.port       # daemon listening port (one integer)
+├── server.log        # daemon stdout + stderr
+└── spawn.lock        # flock target for wrapper concurrency control
+```
+
+The daemon writes `server.pid` and `server.port` atomically immediately after
+a successful `listen()`. It removes both on graceful shutdown. `spawn.lock` is
+created lazily by the first wrapper that needs it and is never deleted.
+
+## Port Selection
+
+- Start from `process.env.MCP_HTTP_PORT ?? 13579`.
+- Bind attempts: up to 10 (i.e. 13579 through 13588).
+- On `EADDRINUSE`, increment and retry. Any other bind error fails fast.
+- Exhausting the range fails with a clear error.
+- Bind host is always `127.0.0.1`.
+
+Rationale for 13579: outside the default Linux ephemeral range (32768–60999,
+so the OS will not pre-empt the port with an outbound connection), not a
+common service port, easy to remember (odd-digit ladder).
+
+## Singleton Enforcement
+
+The wrapper wraps the "check pid → spawn if dead" critical section in an
+exclusive `flock`:
+
+```bash
+(
+  flock -x 200
+  if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+    :  # daemon is alive, proceed
+  else
+    rm -f "$PID_FILE" "$PORT_FILE"
+    nohup node "$DAEMON_BIN" >> "$LOG_FILE" 2>&1 &
+    for i in $(seq 50); do
+      sleep 0.1
+      [[ -f "$PORT_FILE" ]] && break
+    done
+  fi
+) 200>"$LOCK_FILE"
+```
+
+Two wrappers starting simultaneously: only one enters the critical section
+and may spawn; the other blocks on the lock and then sees the freshly-written
+`PORT_FILE` when it gets the lock, proceeding to connect without spawning.
+
+## Lifecycle
+
+### Daemon startup
+
+1. `dotenv.config()` reads `<pkg-root>/.env` (via explicit path resolution
+   relative to `__dirname`, so cwd does not matter).
+2. `initializeBot()` — polling starts, `bot.getMe()` validates the token. On
+   failure, `process.exit(1)` **before** any state file is written, so the
+   next wrapper invocation retries.
+3. `scanAndBind()` — iterate candidate ports; bind `127.0.0.1:<port>`.
+4. Write `server.pid` and `server.port` synchronously.
+5. Enter HTTP event loop.
+
+### Daemon shutdown
+
+Three exit paths, all must leave the state dir consistent:
+
+- `SIGINT` / `SIGTERM`: `bot.stopPolling()`, unlink `server.pid` and
+  `server.port`, `process.exit(0)`.
+- Uncaught exception: `process.on('exit')` hook unlinks the state files
+  synchronously as a safety net.
+- `kill -9`: state files persist with a stale PID. The wrapper's
+  `kill -0 <pid>` probe detects the pid is gone and cleans up on next
+  invocation. State self-heals; no manual intervention needed.
+
+### Wrapper lifecycle
+
+CC closes the session → CC closes the wrapper's stdin → `while IFS= read`
+returns EOF → wrapper exits. **The wrapper never kills the daemon.** The
+daemon is a shared resource; its lifetime is decoupled from any individual
+CC window. The daemon dies only via (1) manual `kill`, (2) machine reboot,
+(3) its own crash.
+
+## Behavior Change: Plain-Message Fallback Removed
+
+Current code has a fallback that routes any plain Telegram message to the
+most recent `ask_user` question if the user did not use the "Reply" feature:
+
+```typescript
+if (!questionId) { questionId = lastQuestionId; }
+```
+
+This is removed as part of this refactor. The new rule: **only messages sent
+via Telegram's "Reply" feature whose `reply_to_message.text` contains a
+recognizable `#<questionId>` tag are routed to `pendingQuestions`**. Plain
+messages are logged and discarded. The `lastQuestionId` module-level
+variable is deleted along with the fallback.
+
+Motivation: with multiple concurrent CC sessions each potentially holding
+open `ask_user` promises on the same daemon, "most recent question" becomes
+ambiguous. The explicit-reply-only rule is unambiguous and scales.
+
+## Error Handling
+
+### Daemon
+
+| Condition | Behavior |
+|---|---|
+| `.env` missing `TELEGRAM_TOKEN` or `CHAT_ID` | Throw on startup; process exits before state files written. |
+| Telegram `getMe` fails | `initializeBot` returns false → `process.exit(1)` before state files written. |
+| All 10 candidate ports occupied | Throw `Error: no free port in 13579-13588`. |
+| Non-JSON POST body | HTTP 400, JSON-RPC `-32700 Parse error`. |
+| Tool handler throws | JSON-RPC `-32000` with the thrown message. |
+| HTTP client disconnects mid-`ask_user` | Daemon's pending promise remains until a Telegram reply arrives; response write fails silently; `pendingQuestions` entry is removed on reply. |
+
+### Wrapper
+
+| Condition | Behavior |
+|---|---|
+| Another wrapper holds `spawn.lock` | `flock` blocks until released — automatic queueing. |
+| 5 seconds elapse without `server.port` appearing | Emit `[mcp-client] daemon failed to start, see ~/.mcp-communicator-telegram/server.log` to stderr; exit 1. CC surfaces this as MCP connection failure. |
+| Daemon dies mid-request (curl returns ECONNREFUSED) | Current request returns HTTP error to CC via JSON-RPC; next request retriggers pid/port probe and lazy respawn. **No automatic retry of the failed request** — CC sees the error via MCP's normal error channel. |
+| CC closes stdin | `while read` hits EOF, wrapper exits cleanly. |
+
+## Repository Changes
+
+`mcp-communicator-telegram` (branch `http-daemon`):
+
+- `src/index.ts` — transport swap (stdio → HTTP), port-scan loop, state-file
+  management, removal of `lastQuestionId` fallback.
+- `bin/mcp-client.sh` — new bash wrapper (~50 lines, executable, shebang).
+- `package.json` — bump version `0.2.1` → `0.3.0`.
+- `README.md` — document the new architecture, state dir, port range, and
+  troubleshooting steps (how to inspect `server.log`, how to force a
+  respawn).
+
+No new npm dependencies. `http` is built-in; `flock` and `curl` are Linux
+standard.
+
+`Abaqus2024/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "mcp-communicator-telegram": {
+      "type": "stdio",
+      "command": "/home/youran/Abaqus2024/mcp-communicator-telegram/bin/mcp-client.sh"
+    }
+  }
+}
+```
+
+## Verification
+
+Executed in order after implementation:
+
+1. **Wrapper-daemon handshake.** `./bin/mcp-client.sh <<< '{"jsonrpc":"2.0","id":1,"method":"initialize",...}'`. Expect daemon to
+   spawn, correct JSON on stdout, `server.{pid,port}` present with valid
+   contents.
+2. **Port conflict fallback.** `nc -l 13579` in one terminal, then run the
+   wrapper. Expect daemon to land on 13580 and write 13580 to `server.port`.
+3. **Self-healing respawn.** `kill -9 $(cat ~/.mcp-communicator-telegram/server.pid)`, then rerun the wrapper. Expect detection of dead pid,
+   cleanup, respawn with new pid.
+4. **Spawn race.** Two shells invoke the wrapper nearly simultaneously.
+   Expect exactly one daemon process (`pgrep -cf "node.*build/index.js" == 1`).
+5. **Multi-session sharing (final acceptance).** Close all CC sessions,
+   `rm -rf ~/.mcp-communicator-telegram`. Open two CC sessions, both
+   starting `/supervisor`. Each calls `ask_user`. Both must receive the
+   Telegram user's replies — **user must use Telegram's "Reply" feature**
+   when answering each question, since the plain-message fallback is
+   removed.
+6. **Plain-message regression.** Send a non-Reply plain message in Telegram.
+   `server.log` should record "No matching question found" and no pending
+   question should be resolved.

--- a/docs/superpowers/specs/2026-04-20-http-daemon-design.md
+++ b/docs/superpowers/specs/2026-04-20-http-daemon-design.md
@@ -72,11 +72,11 @@ daemon already alive.
 
 ## State Layout
 
-Following the `claude-memory-manager` convention — flat single-value files in
-a home dot-dir named after the service:
+Reboot-transient runtime metadata lives in `/tmp` with a per-user suffix to
+avoid collisions on multi-user machines:
 
 ```
-~/.mcp-communicator-telegram/
+/tmp/mcp-communicator-telegram-$USER/
 ├── server.pid        # daemon PID (one integer)
 ├── server.port       # daemon listening port (one integer)
 ├── server.log        # daemon stdout + stderr
@@ -194,7 +194,7 @@ ambiguous. The explicit-reply-only rule is unambiguous and scales.
 | Condition | Behavior |
 |---|---|
 | Another wrapper holds `spawn.lock` | `flock` blocks until released — automatic queueing. |
-| 5 seconds elapse without `server.port` appearing | Emit `[mcp-client] daemon failed to start, see ~/.mcp-communicator-telegram/server.log` to stderr; exit 1. CC surfaces this as MCP connection failure. |
+| 5 seconds elapse without `server.port` appearing | Emit `[mcp-client] daemon failed to start, see /tmp/mcp-communicator-telegram-$USER/server.log` to stderr; exit 1. CC surfaces this as MCP connection failure. |
 | Daemon dies mid-request (curl returns ECONNREFUSED) | Current request returns HTTP error to CC via JSON-RPC; next request retriggers pid/port probe and lazy respawn. **No automatic retry of the failed request** — CC sees the error via MCP's normal error channel. |
 | CC closes stdin | `while read` hits EOF, wrapper exits cleanly. |
 
@@ -235,12 +235,12 @@ Executed in order after implementation:
    contents.
 2. **Port conflict fallback.** `nc -l 13579` in one terminal, then run the
    wrapper. Expect daemon to land on 13580 and write 13580 to `server.port`.
-3. **Self-healing respawn.** `kill -9 $(cat ~/.mcp-communicator-telegram/server.pid)`, then rerun the wrapper. Expect detection of dead pid,
+3. **Self-healing respawn.** `kill -9 $(cat /tmp/mcp-communicator-telegram-$USER/server.pid)`, then rerun the wrapper. Expect detection of dead pid,
    cleanup, respawn with new pid.
 4. **Spawn race.** Two shells invoke the wrapper nearly simultaneously.
    Expect exactly one daemon process (`pgrep -cf "node.*build/index.js" == 1`).
 5. **Multi-session sharing (final acceptance).** Close all CC sessions,
-   `rm -rf ~/.mcp-communicator-telegram`. Open two CC sessions, both
+   `rm -rf /tmp/mcp-communicator-telegram-$USER`. Open two CC sessions, both
    starting `/supervisor`. Each calls `ask_user`. Both must receive the
    Telegram user's replies — **user must use Telegram's "Reply" feature**
    when answering each question, since the plain-message fallback is

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-communicator-telegram",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "MCP server for communicating with users through Telegram bots",
   "main": "build/index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-communicator-telegram",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "MCP server for communicating with users through Telegram bots",
   "main": "build/index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-communicator-telegram",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "MCP server for communicating with users through Telegram bots",
   "main": "build/index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-communicator-telegram",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "MCP server for communicating with users through Telegram bots",
   "main": "build/index.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-communicator-telegram",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "MCP server for communicating with users through Telegram bots",
   "main": "build/index.js",
   "type": "commonjs",

--- a/src/get-chat-id.ts
+++ b/src/get-chat-id.ts
@@ -12,12 +12,12 @@ if (!token) {
 
 const bot = new TelegramBot(token, { polling: true });
 
-console.log('Bot is running. Please send any message to your bot (@cline_communicator_bot)...');
+console.error('Bot is running. Please send any message to your bot (@cline_communicator_bot)...');
 
 bot.on('message', (msg: TelegramBot.Message) => {
-  console.log(`Your Chat ID is: ${msg.chat.id}`);
-  console.log('You can now update your .env file with this ID');
-  console.log('Press Ctrl+C to exit');
+  console.error(`Your Chat ID is: ${msg.chat.id}`);
+  console.error('You can now update your .env file with this ID');
+  console.error('Press Ctrl+C to exit');
 });
 
 // Handle errors

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import * as dotenv from 'dotenv';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as http from 'http';
+import * as os from 'os';
 import archiver from 'archiver';
 import ignore from 'ignore';
 
@@ -18,6 +19,9 @@ const CHAT_ID = process.env.CHAT_ID;
 const HTTP_PORT_START = parseInt(process.env.MCP_HTTP_PORT ?? '13579', 10);
 const HTTP_PORT_TRIES = 10;
 const HTTP_HOST = process.env.MCP_HTTP_HOST ?? '127.0.0.1';
+const STATE_DIR = path.join(os.homedir(), '.mcp-communicator-telegram');
+const PID_FILE = path.join(STATE_DIR, 'server.pid');
+const PORT_FILE = path.join(STATE_DIR, 'server.port');
 
 if (!TELEGRAM_TOKEN || !CHAT_ID) {
   throw new Error('TELEGRAM_TOKEN and CHAT_ID are required in .env file');
@@ -493,7 +497,12 @@ async function main() {
     console.error('Failed to initialize bot, exiting...');
     process.exit(1);
   }
-  await startHttpServer();
+  const { port } = await startHttpServer();
+
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  fs.writeFileSync(PID_FILE, `${process.pid}\n`);
+  fs.writeFileSync(PORT_FILE, `${port}\n`);
+  console.error(`State recorded: pid=${process.pid} port=${port} in ${STATE_DIR}`);
 }
 
 main().catch(error => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ const CHAT_ID = process.env.CHAT_ID;
 const HTTP_PORT_START = parseInt(process.env.MCP_HTTP_PORT ?? '13579', 10);
 const HTTP_PORT_TRIES = 10;
 const HTTP_HOST = process.env.MCP_HTTP_HOST ?? '127.0.0.1';
-const STATE_DIR = path.join(os.homedir(), '.mcp-communicator-telegram');
+const STATE_DIR = path.join('/tmp', `mcp-communicator-telegram-${os.userInfo().username}`);
 const PID_FILE = path.join(STATE_DIR, 'server.pid');
 const PORT_FILE = path.join(STATE_DIR, 'server.port');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,15 @@ import * as path from 'path';
 import * as http from 'http';
 import * as os from 'os';
 import * as crypto from 'crypto';
+import * as dns from 'dns';
 import archiver from 'archiver';
 import ignore from 'ignore';
+
+// api.telegram.org resolves to both A and AAAA records. When the host's
+// IPv6 route is dead but DNS still hands out the AAAA first (default OS
+// order), every Telegram HTTPS call ends in `EFATAL: AggregateError` and
+// the bot stops working. Pinning IPv4-first sidesteps that.
+dns.setDefaultResultOrder('ipv4first');
 
 // Load .env from the package root so the daemon works regardless of cwd.
 dotenv.config({ path: path.resolve(__dirname, '..', '.env') });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,21 @@
 import TelegramBot = require('node-telegram-bot-api');
 import * as dotenv from 'dotenv';
 import * as fs from 'fs';
+import * as path from 'path';
+import * as http from 'http';
 import archiver from 'archiver';
+import ignore from 'ignore';
 
-dotenv.config();
+// Load .env from the package root so the daemon works regardless of cwd.
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
 
 // Enable proper file content-type handling
 process.env.NTBA_FIX_350 = '1';
 
 const TELEGRAM_TOKEN = process.env.TELEGRAM_TOKEN;
 const CHAT_ID = process.env.CHAT_ID;
+const HTTP_PORT = parseInt(process.env.MCP_HTTP_PORT ?? '8765', 10);
+const HTTP_HOST = process.env.MCP_HTTP_HOST ?? '127.0.0.1';
 
 if (!TELEGRAM_TOKEN || !CHAT_ID) {
   throw new Error('TELEGRAM_TOKEN and CHAT_ID are required in .env file');
@@ -23,13 +29,11 @@ let lastQuestionId: string | null = null;
 
 async function initializeBot() {
   try {
-    // Create new bot instance with minimal polling configuration
     bot = new TelegramBot(TELEGRAM_TOKEN!, {
       polling: true,
-      filepath: false  // Disable file downloading to avoid timeouts
+      filepath: false
     });
-    
-    // Handler function for messages
+
     const handleMessage = (msg: TelegramBot.Message) => {
       console.error('Received message:', {
         chatId: msg.chat.id.toString(),
@@ -37,33 +41,30 @@ async function initializeBot() {
         text: msg.text,
         replyToMessage: msg.reply_to_message?.text
       });
-    
+
       if (msg.chat.id.toString() !== validatedChatId || !msg.text) {
         console.error('Message rejected: chat ID mismatch or no text');
         return;
       }
-      
-      // Extract question ID from reply or use last question ID
+
       let questionId = null;
-      
+
       if (msg.reply_to_message?.text) {
         const match = msg.reply_to_message.text.match(/#([a-z0-9]+)\n/);
         if (match) {
           questionId = match[1];
         }
       }
-      
-      // If no question ID found in reply, use lastQuestionId
+
       if (!questionId) {
         questionId = lastQuestionId;
       }
-      
+
       console.error('Question ID (from reply or last):', questionId);
       console.error('Pending questions:', Array.from(pendingQuestions.keys()));
-      
+
       if (questionId && pendingQuestions.has(questionId)) {
         console.error('Found matching question with ID:', questionId);
-        console.error('Found matching question, resolving...');
         const resolver = pendingQuestions.get(questionId)!;
         resolver(msg.text);
         pendingQuestions.delete(questionId);
@@ -73,37 +74,25 @@ async function initializeBot() {
         console.error('No matching question found for this response');
       }
     };
-    
-    // Set up message handler
+
     bot.on('message', handleMessage);
-    
-    // Handle polling errors
+
     bot.on('polling_error', (error: Error) => {
       if (error.message.includes('409 Conflict')) {
-        // Ignore 409 Conflict errors as they're expected when restarting
         return;
       }
       console.error('Polling error:', error.message);
     });
-    
-    // Test the connection
+
     const botInfo = await bot.getMe();
     console.error('Bot initialized successfully:', botInfo.username);
-    
-    // Clean up on process termination
-    process.once('SIGINT', () => {
-      if (bot) {
-        bot.stopPolling();
-      }
-      process.exit(0);
-    });
-    
+
     return true;
-    } catch (error: any) {
+  } catch (error: any) {
     console.error('Error initializing bot:', error?.message || 'Unknown error');
     return false;
-    }
-    }
+  }
+}
 
 interface AskUserParams {
   question: string;
@@ -119,7 +108,7 @@ async function notifyUser(params: NotifyUserParams): Promise<void> {
   }
 
   const { message } = params;
-  
+
   try {
     await bot.sendMessage(parseInt(validatedChatId), message);
     console.error('Notification sent successfully');
@@ -137,9 +126,9 @@ async function askUser(params: AskUserParams): Promise<string> {
   const { question } = params;
   const questionId = Math.random().toString(36).substring(7);
   lastQuestionId = questionId;
-  
+
   console.error('Asking question with ID:', questionId);
-  
+
   try {
     await bot.sendMessage(parseInt(validatedChatId), `#${questionId}\n${question}`, {
       reply_markup: {
@@ -148,13 +137,11 @@ async function askUser(params: AskUserParams): Promise<string> {
       }
     });
     console.error('Question sent successfully');
-    
+
     const response = await new Promise<string>((resolve) => {
-      console.error('Adding question to pending map...');
       pendingQuestions.set(questionId, resolve);
-      // No timeout - will wait indefinitely for a response
     });
-    
+
     console.error('Received response:', response);
     return response;
   } catch (error: any) {
@@ -183,10 +170,6 @@ async function sendFile(params: { filePath: string }): Promise<void> {
   }
 }
 
-import ignore from 'ignore';
-
-import * as path from 'path';
-
 async function zipProject(params: { directory?: string } = {}): Promise<void> {
   const workingDir = params.directory || process.cwd();
   const projectName = path.basename(workingDir);
@@ -198,7 +181,7 @@ async function zipProject(params: { directory?: string } = {}): Promise<void> {
   ig.add(gitignoreContent);
 
   const outputPath = path.join(workingDir, `${projectName}-project.zip`);
-  
+
   await new Promise<void>((resolve, reject) => {
     const output = fs.createWriteStream(outputPath);
     const archive = archiver('zip', {
@@ -216,19 +199,17 @@ async function zipProject(params: { directory?: string } = {}): Promise<void> {
 
     archive.pipe(output);
 
-    // Add files that aren't ignored by .gitignore
     const addFilesFromDirectory = (dirPath: string) => {
       const files = fs.readdirSync(dirPath);
-      
+
       for (const file of files) {
         const fullPath = path.join(dirPath, file);
         const relativePath = path.relative(workingDir, fullPath);
-        
-        // Skip .git directory
+
         if (relativePath.startsWith('.git')) {
           continue;
         }
-        
+
         const stat = fs.statSync(fullPath);
         if (stat.isDirectory()) {
           addFilesFromDirectory(fullPath);
@@ -244,294 +225,255 @@ async function zipProject(params: { directory?: string } = {}): Promise<void> {
     archive.finalize();
   });
 
-  // Check if file size exceeds 2GB
   const stats = fs.statSync(outputPath);
   const TWO_GB = 2 * 1024 * 1024 * 1024;
-  
+
   if (stats.size > TWO_GB) {
-    fs.unlinkSync(outputPath); // Clean up the oversized file
+    fs.unlinkSync(outputPath);
     throw new Error('File size exceeds 2GB limit. Please implement file splitting or reduce the project size.');
   }
 }
 
-
-// MCP Server Implementation
-class McpServer {
-  private buffer = '';
-
-  constructor() {
-    // Don't send initialization message - wait for initialize request
-
-    // Set up stdin handling
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', this.handleInput.bind(this));
+// JSON-RPC dispatcher: returns the response object, or null for notifications.
+async function dispatchRequest(request: any): Promise<any | null> {
+  // JSON-RPC notifications have no `id` field and MUST NOT receive a response.
+  if (!('id' in request)) {
+    return null;
   }
 
-  private sendResponse(response: any) {
-    process.stdout.write(JSON.stringify(response) + "\n");
-  }
-
-  private handleInput(chunk: string) {
-    this.buffer += chunk;
-    const messages = this.buffer.split('\n');
-    this.buffer = messages.pop() || '';
-
-    for (const message of messages) {
-      try {
-        const request = JSON.parse(message);
-        this.handleRequest(request).catch(error => {
-          console.error('Error handling request:', error);
-          this.sendResponse({
-            jsonrpc: "2.0",
-            id: request.id,
-            error: {
-              code: -32000,
-              message: error.message
+  switch (request.method) {
+    case 'initialize':
+      return {
+        jsonrpc: "2.0",
+        id: request.id,
+        result: {
+          protocolVersion: "2024-11-05",
+          serverInfo: {
+            name: "mcp-communicator-telegram",
+            version: "0.3.0"
+          },
+          capabilities: {
+            tools: {
+              listTools: true,
+              callTool: true
             }
-          });
-        });
-      } catch (error) {
-        console.error('Error parsing message:', error);
-      }
-    }
-  }
-
-  private async handleRequest(request: any) {
-    console.error('Received request:', request);
-
-    // JSON-RPC notifications have no `id` field and MUST NOT receive a response.
-    // Examples: notifications/initialized, notifications/cancelled.
-    if (!('id' in request)) {
-      return;
-    }
-
-    switch (request.method) {
-      case 'initialize':
-        // Respond with required initialization info
-        this.sendResponse({
-          jsonrpc: "2.0",
-          id: request.id,
-          result: {
-            protocolVersion: "2024-11-05",
-            serverInfo: {
-              name: "mcp-communicator-telegram",
-              version: "0.2.1"
-            },
-            capabilities: {
-              tools: {
-                listTools: true,
-                callTool: true
-              }
-            },
-            instructions: "Human-in-the-loop bridge to a real person over a Telegram chat."
-          }
-        });
-        break;
-  
-      case 'tools/list':
-        this.sendResponse({
-          jsonrpc: "2.0",
-          id: request.id,
-          result: {
-            tools: [
-              {
-                name: "ask_user",
-                description: "Ask the user a question via Telegram and wait for their response",
-                inputSchema: {
-                  type: "object",
-                  properties: {
-                    question: {
-                      type: "string",
-                      description: "The question to ask the user"
-                    }
-                  },
-                  required: ["question"]
-                }
-              },
-              {
-                name: "notify_user",
-                description: "Send a notification message to the user via Telegram (no response required)",
-                inputSchema: {
-                  type: "object",
-                  properties: {
-                    message: {
-                      type: "string",
-                      description: "The message to send to the user"
-                    }
-                  },
-                  required: ["message"]
-                }
-              },
-              {
-                name: "send_file",
-                description: "Send a file to the user via Telegram",
-                inputSchema: {
-                  type: "object",
-                  properties: {
-                    filePath: {
-                      type: "string",
-                      description: "The path to the file to send"
-                    }
-                  },
-                  required: ["filePath"]
-                }
-              },
-              {
-                name: "zip_project",
-                description: "Zip a project directory and send it to the user",
-                inputSchema: {
-                  type: "object",
-                  properties: {
-                    directory: {
-                      type: "string",
-                      description: "Directory to zip (defaults to current working directory)"
-                    }
-                  },
-                  required: []
-                }
-              }
-            ]
-          }
-        });
-        break;
-
-      case 'tools/call':
-        try {
-          switch (request.params.name) {
-            case 'ask_user':
-              const answer = await askUser(request.params.arguments);
-              this.sendResponse({
-                jsonrpc: "2.0",
-                id: request.id,
-                result: {
-                  content: [{
-                    type: "text",
-                    text: answer
-                  }]
-                }
-              });
-              break;
-
-            case 'notify_user':
-              await notifyUser(request.params.arguments);
-              this.sendResponse({
-                jsonrpc: "2.0",
-                id: request.id,
-                result: {
-                  content: [{
-                    type: "text",
-                    text: "Notification sent successfully"
-                  }]
-                }
-              });
-              break;
-
-            case 'send_file':
-              await sendFile(request.params.arguments);
-              this.sendResponse({
-                jsonrpc: "2.0",
-                id: request.id,
-                result: {
-                  content: [{
-                    type: "text",
-                    text: "File sent successfully"
-                  }]
-                }
-              });
-              break;
-
-            case 'zip_project':
-              {
-                const workingDir = request.params.arguments?.directory || process.cwd();
-                const projectName = path.basename(workingDir);
-                const zipFilePath = path.join(workingDir, `${projectName}-project.zip`);
-
-                // Clean up any existing zip file first
-                try {
-                  if (fs.existsSync(zipFilePath)) {
-                    fs.unlinkSync(zipFilePath);
-                  }
-                } catch (error) {
-                  console.error('Error cleaning up existing zip file:', error);
-                }
-
-                try {
-                  await zipProject(request.params.arguments);
-                  await sendFile({ filePath: zipFilePath });
-                  // Clean up the zip file after sending
-                  if (fs.existsSync(zipFilePath)) {
-                    fs.unlinkSync(zipFilePath);
-                  }
-                  this.sendResponse({
-                    jsonrpc: "2.0",
-                    id: request.id,
-                    result: {
-                      content: [{
-                        type: "text",
-                        text: "Project zipped and sent successfully"
-                      }]
-                    }
-                  });
-                } catch (error) {
-                  // Clean up zip file if it exists after error
-                  try {
-                    if (fs.existsSync(zipFilePath)) {
-                      fs.unlinkSync(zipFilePath);
-                    }
-                  } catch (cleanupError) {
-                    console.error('Error cleaning up zip file after error:', cleanupError);
-                  }
-                  throw error;
-                }
-              }
-              break;
-
-            default:
-              throw new Error(`Unknown tool: ${request.params.name}`);
-          }
-        } catch (error: any) {
-          this.sendResponse({
-            jsonrpc: "2.0",
-            id: request.id,
-            error: {
-              code: -32000,
-              message: error.message
-            }
-          });
+          },
+          instructions: "Human-in-the-loop bridge to a real person over a Telegram chat."
         }
-        break;
+      };
 
-      default:
-        this.sendResponse({
+    case 'tools/list':
+      return {
+        jsonrpc: "2.0",
+        id: request.id,
+        result: {
+          tools: [
+            {
+              name: "ask_user",
+              description: "Ask the user a question via Telegram and wait for their response",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  question: {
+                    type: "string",
+                    description: "The question to ask the user"
+                  }
+                },
+                required: ["question"]
+              }
+            },
+            {
+              name: "notify_user",
+              description: "Send a notification message to the user via Telegram (no response required)",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  message: {
+                    type: "string",
+                    description: "The message to send to the user"
+                  }
+                },
+                required: ["message"]
+              }
+            },
+            {
+              name: "send_file",
+              description: "Send a file to the user via Telegram",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  filePath: {
+                    type: "string",
+                    description: "The path to the file to send"
+                  }
+                },
+                required: ["filePath"]
+              }
+            },
+            {
+              name: "zip_project",
+              description: "Zip a project directory and send it to the user",
+              inputSchema: {
+                type: "object",
+                properties: {
+                  directory: {
+                    type: "string",
+                    description: "Directory to zip (defaults to current working directory)"
+                  }
+                },
+                required: []
+              }
+            }
+          ]
+        }
+      };
+
+    case 'tools/call':
+      try {
+        let result: any;
+        switch (request.params.name) {
+          case 'ask_user': {
+            const answer = await askUser(request.params.arguments);
+            result = { content: [{ type: "text", text: answer }] };
+            break;
+          }
+          case 'notify_user': {
+            await notifyUser(request.params.arguments);
+            result = { content: [{ type: "text", text: "Notification sent successfully" }] };
+            break;
+          }
+          case 'send_file': {
+            await sendFile(request.params.arguments);
+            result = { content: [{ type: "text", text: "File sent successfully" }] };
+            break;
+          }
+          case 'zip_project': {
+            const workingDir = request.params.arguments?.directory || process.cwd();
+            const projectName = path.basename(workingDir);
+            const zipFilePath = path.join(workingDir, `${projectName}-project.zip`);
+
+            try {
+              if (fs.existsSync(zipFilePath)) {
+                fs.unlinkSync(zipFilePath);
+              }
+            } catch (error) {
+              console.error('Error cleaning up existing zip file:', error);
+            }
+
+            try {
+              await zipProject(request.params.arguments);
+              await sendFile({ filePath: zipFilePath });
+              if (fs.existsSync(zipFilePath)) {
+                fs.unlinkSync(zipFilePath);
+              }
+              result = { content: [{ type: "text", text: "Project zipped and sent successfully" }] };
+            } catch (error) {
+              try {
+                if (fs.existsSync(zipFilePath)) {
+                  fs.unlinkSync(zipFilePath);
+                }
+              } catch (cleanupError) {
+                console.error('Error cleaning up zip file after error:', cleanupError);
+              }
+              throw error;
+            }
+            break;
+          }
+          default:
+            throw new Error(`Unknown tool: ${request.params.name}`);
+        }
+        return { jsonrpc: "2.0", id: request.id, result };
+      } catch (error: any) {
+        return {
           jsonrpc: "2.0",
           id: request.id,
-          error: {
-            code: -32601,
-            message: `Method not found: ${request.method}`
-          }
-        });
-    }
+          error: { code: -32000, message: error.message }
+        };
+      }
+
+    default:
+      return {
+        jsonrpc: "2.0",
+        id: request.id,
+        error: { code: -32601, message: `Method not found: ${request.method}` }
+      };
   }
 }
 
-// Handle process termination
-process.on('SIGINT', () => {
+function startHttpServer() {
+  const server = http.createServer((req, res) => {
+    if (req.method !== 'POST' || !req.url?.startsWith('/mcp')) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('not found\n');
+      return;
+    }
+
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', async () => {
+      let request: any;
+      try {
+        request = JSON.parse(body);
+      } catch (error) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: -32700, message: 'Parse error' }
+        }));
+        return;
+      }
+
+      try {
+        const response = await dispatchRequest(request);
+        if (response === null) {
+          res.writeHead(202);
+          res.end();
+        } else {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(response));
+        }
+      } catch (error: any) {
+        console.error('Error handling request:', error);
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          jsonrpc: "2.0",
+          id: request?.id ?? null,
+          error: { code: -32000, message: error.message }
+        }));
+      }
+    });
+  });
+
+  // ask_user can block indefinitely on a human reply; disable all idle timeouts.
+  server.requestTimeout = 0;
+  server.headersTimeout = 0;
+  server.keepAliveTimeout = 0;
+
+  server.listen(HTTP_PORT, HTTP_HOST, () => {
+    console.error(`MCP HTTP server listening on http://${HTTP_HOST}:${HTTP_PORT}/mcp`);
+  });
+
+  return server;
+}
+
+const shutdown = () => {
   if (bot) {
     bot.stopPolling();
   }
   process.exit(0);
-});
+};
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
 
-// Initialize the bot and MCP server
 async function main() {
   const success = await initializeBot();
   if (!success) {
     console.error('Failed to initialize bot, exiting...');
     process.exit(1);
   }
-  
-  console.error('MCP Communicator server running...');
-  new McpServer(); // Start the MCP server
+  startHttpServer();
 }
 
 main().catch(error => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as http from 'http';
 import * as os from 'os';
+import * as crypto from 'crypto';
 import archiver from 'archiver';
 import ignore from 'ignore';
 
@@ -19,13 +20,27 @@ const CHAT_ID = process.env.CHAT_ID;
 const HTTP_PORT_START = parseInt(process.env.MCP_HTTP_PORT ?? '13579', 10);
 const HTTP_PORT_TRIES = 10;
 const HTTP_HOST = process.env.MCP_HTTP_HOST ?? '127.0.0.1';
-const STATE_DIR = path.join('/tmp', `mcp-communicator-telegram-${os.userInfo().username}`);
-const PID_FILE = path.join(STATE_DIR, 'server.pid');
-const PORT_FILE = path.join(STATE_DIR, 'server.port');
 
 if (!TELEGRAM_TOKEN || !CHAT_ID) {
   throw new Error('TELEGRAM_TOKEN and CHAT_ID are required in .env file');
 }
+
+// STATE_DIR is keyed by sha256(TELEGRAM_TOKEN). Telegram's getUpdates is
+// mutually exclusive at the bot-token level, so one daemon per token is the
+// physical maximum; hashing the token (not the chat id) lets multiple
+// installs with different bots run side by side without colliding, and lets
+// multiple Claude Code sessions sharing the same bot reuse one daemon.
+const instanceHash = crypto
+  .createHash('sha256')
+  .update(TELEGRAM_TOKEN)
+  .digest('hex')
+  .slice(0, 8);
+const STATE_DIR = path.join(
+  '/tmp',
+  `mcp-communicator-telegram-${os.userInfo().username}-${instanceHash}`,
+);
+const PID_FILE = path.join(STATE_DIR, 'server.pid');
+const PORT_FILE = path.join(STATE_DIR, 'server.port');
 
 const validatedChatId = CHAT_ID as string;
 let bot: TelegramBot | null = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -413,7 +413,7 @@ async function dispatchRequest(request: any): Promise<DispatchResult | null> {
           }
           case 'notify_user': {
             await notifyUser(request.params.arguments);
-            result = { content: [{ type: "text", text: "Notification sent successfully" }] };
+            result = { content: [{ type: "text", text: "Notification sent successfully. This is a one-way channel — you will NOT receive a user reply through this tool. If you need a response, use ask_user instead." }] };
             break;
           }
           case 'send_file': {

--- a/src/index.ts
+++ b/src/index.ts
@@ -589,37 +589,6 @@ process.on('SIGTERM', shutdown);
 process.on('exit', cleanupState);
 
 async function main() {
-  // Refuse to start if another daemon with the same token is already
-  // listening on the port recorded in PORT_FILE.  This check works
-  // cross-user because it uses HTTP, unlike process.kill(pid, 0).
-  try {
-    const existingPort = fs.readFileSync(PORT_FILE, 'utf8').trim();
-    if (existingPort) {
-      const alive = await new Promise<boolean>((resolve) => {
-        const req = http.request({
-          hostname: HTTP_HOST,
-          port: parseInt(existingPort),
-          path: '/mcp',
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          timeout: 1000,
-        }, () => resolve(true));
-        req.on('error', () => resolve(false));
-        req.on('timeout', () => { req.destroy(); resolve(false); });
-        req.write(JSON.stringify({ jsonrpc: '2.0', method: 'ping', id: 'health' }));
-        req.end();
-      });
-      if (alive) {
-        console.error(
-          `Daemon already running on port ${existingPort}, exiting.`,
-        );
-        process.exit(0);
-      }
-    }
-  } catch {
-    // PORT_FILE doesn't exist or is unreadable — no daemon to conflict with.
-  }
-
   const success = await initializeBot();
   if (!success) {
     console.error('Failed to initialize bot, exiting...');

--- a/src/index.ts
+++ b/src/index.ts
@@ -482,14 +482,21 @@ async function startHttpServer(): Promise<{ server: http.Server; port: number }>
   throw new Error(`No free port in range ${HTTP_PORT_START}-${HTTP_PORT_START + HTTP_PORT_TRIES - 1}`);
 }
 
+const cleanupState = () => {
+  try { fs.unlinkSync(PID_FILE); } catch {}
+  try { fs.unlinkSync(PORT_FILE); } catch {}
+};
+
 const shutdown = () => {
   if (bot) {
     bot.stopPolling();
   }
+  cleanupState();
   process.exit(0);
 };
 process.on('SIGINT', shutdown);
 process.on('SIGTERM', shutdown);
+process.on('exit', cleanupState);
 
 async function main() {
   const success = await initializeBot();

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,18 +187,32 @@ async function askUser(params: AskUserParams): Promise<PendingReply> {
 // this MUST run only after the JSON-RPC response is flushed to the wrapper.
 async function reactWithOk(chatId: number, messageId: number): Promise<void> {
   const url = `https://api.telegram.org/bot${TELEGRAM_TOKEN}/setMessageReaction`;
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      chat_id: chatId,
-      message_id: messageId,
-      reaction: [{ type: 'emoji', emoji: '👌' }],
-    }),
+  const body = JSON.stringify({
+    chat_id: chatId,
+    message_id: messageId,
+    reaction: [{ type: 'emoji', emoji: '👌' }],
   });
-  if (!res.ok) {
-    const body = await res.text().catch(() => '<no body>');
-    throw new Error(`setMessageReaction ${res.status}: ${body}`);
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => '<no body>');
+        throw new Error(`setMessageReaction ${res.status}: ${text}`);
+      }
+      return; // success
+    } catch (err: any) {
+      if (attempt < 2) {
+        console.error(`👌 attempt ${attempt + 1} failed, retrying in 60s:`, err?.message ?? err);
+        await new Promise(r => setTimeout(r, 60_000));
+      } else {
+        throw err; // last attempt, let caller handle
+      }
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,7 +333,7 @@ async function dispatchRequest(request: any): Promise<DispatchResult | null> {
             tools: [
             {
               name: "ask_user",
-              description: "Ask the user a question via Telegram and wait for their response",
+              description: "Ask the user a question via Telegram and wait for their response (blocks you until the user replies)",
               inputSchema: {
                 type: "object",
                 properties: {
@@ -347,7 +347,7 @@ async function dispatchRequest(request: any): Promise<DispatchResult | null> {
             },
             {
               name: "notify_user",
-              description: "Send a notification message to the user via Telegram (no response required)",
+              description: "Send a notification message to the user via Telegram (you will not receive a reply)",
               inputSchema: {
                 type: "object",
                 properties: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -589,6 +589,37 @@ process.on('SIGTERM', shutdown);
 process.on('exit', cleanupState);
 
 async function main() {
+  // Refuse to start if another daemon with the same token is already
+  // listening on the port recorded in PORT_FILE.  This check works
+  // cross-user because it uses HTTP, unlike process.kill(pid, 0).
+  try {
+    const existingPort = fs.readFileSync(PORT_FILE, 'utf8').trim();
+    if (existingPort) {
+      const alive = await new Promise<boolean>((resolve) => {
+        const req = http.request({
+          hostname: HTTP_HOST,
+          port: parseInt(existingPort),
+          path: '/mcp',
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          timeout: 1000,
+        }, () => resolve(true));
+        req.on('error', () => resolve(false));
+        req.on('timeout', () => { req.destroy(); resolve(false); });
+        req.write(JSON.stringify({ jsonrpc: '2.0', method: 'ping', id: 'health' }));
+        req.end();
+      });
+      if (alive) {
+        console.error(
+          `Daemon already running on port ${existingPort}, exiting.`,
+        );
+        process.exit(0);
+      }
+    }
+  } catch {
+    // PORT_FILE doesn't exist or is unreadable — no daemon to conflict with.
+  }
+
   const success = await initializeBot();
   if (!success) {
     console.error('Failed to initialize bot, exiting...');

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,11 +32,12 @@ if (!TELEGRAM_TOKEN || !CHAT_ID) {
   throw new Error('TELEGRAM_TOKEN and CHAT_ID are required in .env file');
 }
 
-// STATE_DIR is keyed by sha256(TELEGRAM_TOKEN). Telegram's getUpdates is
+// STATE_DIR is keyed only by sha256(TELEGRAM_TOKEN). Telegram's getUpdates is
 // mutually exclusive at the bot-token level, so one daemon per token is the
-// physical maximum; hashing the token (not the chat id) lets multiple
-// installs with different bots run side by side without colliding, and lets
-// multiple Claude Code sessions sharing the same bot reuse one daemon.
+// physical maximum; we therefore key by token alone and let any user with the
+// same token reuse the same daemon. Different bots get different hashes and
+// run side by side. The wrapper sets group=sudo + setgid (2770) so all sudo
+// members can share the dir; new files inherit gid=sudo and get mode 0o660.
 const instanceHash = crypto
   .createHash('sha256')
   .update(TELEGRAM_TOKEN)
@@ -44,7 +45,7 @@ const instanceHash = crypto
   .slice(0, 8);
 const STATE_DIR = path.join(
   '/tmp',
-  `mcp-communicator-telegram-${os.userInfo().username}-${instanceHash}`,
+  `mcp-communicator-telegram-${instanceHash}`,
 );
 const PID_FILE = path.join(STATE_DIR, 'server.pid');
 const PORT_FILE = path.join(STATE_DIR, 'server.port');
@@ -310,7 +311,7 @@ async function dispatchRequest(request: any): Promise<DispatchResult | null> {
             protocolVersion: "2024-11-05",
             serverInfo: {
               name: "mcp-communicator-telegram",
-              version: "0.3.0"
+              version: "0.3.1"
             },
             capabilities: {
               tools: {
@@ -586,11 +587,13 @@ async function main() {
   }
   const { port } = await startHttpServer();
 
-  // mode 0o700 keeps server.log (which contains ask_user question/answer
-  // bodies) private on multi-user hosts.
-  fs.mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
-  fs.writeFileSync(PID_FILE, `${process.pid}\n`, { mode: 0o600 });
-  fs.writeFileSync(PORT_FILE, `${port}\n`, { mode: 0o600 });
+  // mode 0o2770 = setgid + group rwx so other sudo members can share the dir
+  // (see STATE_DIR keying comment). When the wrapper spawned us, it already
+  // did mkdir + chgrp sudo + chmod 2770, so this path is normally a no-op;
+  // the explicit mode here is for the standalone-launch case.
+  fs.mkdirSync(STATE_DIR, { recursive: true, mode: 0o2770 });
+  fs.writeFileSync(PID_FILE, `${process.pid}\n`, { mode: 0o660 });
+  fs.writeFileSync(PORT_FILE, `${port}\n`, { mode: 0o660 });
   console.error(`State recorded: pid=${process.pid} port=${port} in ${STATE_DIR}`);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,6 @@ if (!TELEGRAM_TOKEN || !CHAT_ID) {
 const validatedChatId = CHAT_ID as string;
 let bot: TelegramBot | null = null;
 const pendingQuestions = new Map<string, (answer: string) => void>();
-let lastQuestionId: string | null = null;
 
 async function initializeBot() {
   try {
@@ -61,11 +60,7 @@ async function initializeBot() {
         }
       }
 
-      if (!questionId) {
-        questionId = lastQuestionId;
-      }
-
-      console.error('Question ID (from reply or last):', questionId);
+      console.error('Question ID (from Reply only):', questionId);
       console.error('Pending questions:', Array.from(pendingQuestions.keys()));
 
       if (questionId && pendingQuestions.has(questionId)) {
@@ -73,7 +68,6 @@ async function initializeBot() {
         const resolver = pendingQuestions.get(questionId)!;
         resolver(msg.text);
         pendingQuestions.delete(questionId);
-        lastQuestionId = null;
         console.error('Question resolved and removed from pending');
       } else {
         console.error('No matching question found for this response');
@@ -130,7 +124,6 @@ async function askUser(params: AskUserParams): Promise<string> {
 
   const { question } = params;
   const questionId = Math.random().toString(36).substring(7);
-  lastQuestionId = questionId;
 
   console.error('Asking question with ID:', questionId);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,7 +322,8 @@ class McpServer {
                 listTools: true,
                 callTool: true
               }
-            }
+            },
+            instructions: "Human-in-the-loop bridge to a real person over a Telegram chat."
           }
         });
         break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ async function initializeBot() {
     
     // Handler function for messages
     const handleMessage = (msg: TelegramBot.Message) => {
-      console.log('Received message:', {
+      console.error('Received message:', {
         chatId: msg.chat.id.toString(),
         expectedChatId: validatedChatId,
         text: msg.text,
@@ -39,7 +39,7 @@ async function initializeBot() {
       });
     
       if (msg.chat.id.toString() !== validatedChatId || !msg.text) {
-        console.log('Message rejected: chat ID mismatch or no text');
+        console.error('Message rejected: chat ID mismatch or no text');
         return;
       }
       
@@ -58,19 +58,19 @@ async function initializeBot() {
         questionId = lastQuestionId;
       }
       
-      console.log('Question ID (from reply or last):', questionId);
-      console.log('Pending questions:', Array.from(pendingQuestions.keys()));
+      console.error('Question ID (from reply or last):', questionId);
+      console.error('Pending questions:', Array.from(pendingQuestions.keys()));
       
       if (questionId && pendingQuestions.has(questionId)) {
-        console.log('Found matching question with ID:', questionId);
-        console.log('Found matching question, resolving...');
+        console.error('Found matching question with ID:', questionId);
+        console.error('Found matching question, resolving...');
         const resolver = pendingQuestions.get(questionId)!;
         resolver(msg.text);
         pendingQuestions.delete(questionId);
         lastQuestionId = null;
-        console.log('Question resolved and removed from pending');
+        console.error('Question resolved and removed from pending');
       } else {
-        console.log('No matching question found for this response');
+        console.error('No matching question found for this response');
       }
     };
     
@@ -88,7 +88,7 @@ async function initializeBot() {
     
     // Test the connection
     const botInfo = await bot.getMe();
-    console.log('Bot initialized successfully:', botInfo.username);
+    console.error('Bot initialized successfully:', botInfo.username);
     
     // Clean up on process termination
     process.once('SIGINT', () => {
@@ -122,7 +122,7 @@ async function notifyUser(params: NotifyUserParams): Promise<void> {
   
   try {
     await bot.sendMessage(parseInt(validatedChatId), message);
-    console.log('Notification sent successfully');
+    console.error('Notification sent successfully');
   } catch (error: any) {
     console.error('Error in notifyUser:', error);
     throw new Error(`Failed to send notification: ${error.message}`);
@@ -138,7 +138,7 @@ async function askUser(params: AskUserParams): Promise<string> {
   const questionId = Math.random().toString(36).substring(7);
   lastQuestionId = questionId;
   
-  console.log('Asking question with ID:', questionId);
+  console.error('Asking question with ID:', questionId);
   
   try {
     await bot.sendMessage(parseInt(validatedChatId), `#${questionId}\n${question}`, {
@@ -147,15 +147,15 @@ async function askUser(params: AskUserParams): Promise<string> {
         selective: true
       }
     });
-    console.log('Question sent successfully');
+    console.error('Question sent successfully');
     
     const response = await new Promise<string>((resolve) => {
-      console.log('Adding question to pending map...');
+      console.error('Adding question to pending map...');
       pendingQuestions.set(questionId, resolve);
       // No timeout - will wait indefinitely for a response
     });
     
-    console.log('Received response:', response);
+    console.error('Received response:', response);
     return response;
   } catch (error: any) {
     console.error('Error in askUser:', error);
@@ -176,7 +176,7 @@ async function sendFile(params: { filePath: string }): Promise<void> {
       contentType: 'application/octet-stream',
       filename: path.basename(filePath)
     });
-    console.log('File sent successfully');
+    console.error('File sent successfully');
   } catch (error: any) {
     console.error('Error in sendFile:', error);
     throw new Error(`Failed to send file: ${error.message}`);
@@ -206,7 +206,7 @@ async function zipProject(params: { directory?: string } = {}): Promise<void> {
     });
 
     output.on('close', () => {
-      console.log(`Zipped ${archive.pointer()} total bytes`);
+      console.error(`Zipped ${archive.pointer()} total bytes`);
       resolve();
     });
 
@@ -297,8 +297,14 @@ class McpServer {
   }
 
   private async handleRequest(request: any) {
-    console.log('Received request:', request);
-  
+    console.error('Received request:', request);
+
+    // JSON-RPC notifications have no `id` field and MUST NOT receive a response.
+    // Examples: notifications/initialized, notifications/cancelled.
+    if (!('id' in request)) {
+      return;
+    }
+
     switch (request.method) {
       case 'initialize':
         // Respond with required initialization info
@@ -523,7 +529,7 @@ async function main() {
     process.exit(1);
   }
   
-  console.log('MCP Communicator server running...');
+  console.error('MCP Communicator server running...');
   new McpServer(); // Start the MCP server
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,8 @@ process.env.NTBA_FIX_350 = '1';
 
 const TELEGRAM_TOKEN = process.env.TELEGRAM_TOKEN;
 const CHAT_ID = process.env.CHAT_ID;
-const HTTP_PORT = parseInt(process.env.MCP_HTTP_PORT ?? '8765', 10);
+const HTTP_PORT_START = parseInt(process.env.MCP_HTTP_PORT ?? '13579', 10);
+const HTTP_PORT_TRIES = 10;
 const HTTP_HOST = process.env.MCP_HTTP_HOST ?? '127.0.0.1';
 
 if (!TELEGRAM_TOKEN || !CHAT_ID) {
@@ -400,7 +401,7 @@ async function dispatchRequest(request: any): Promise<any | null> {
   }
 }
 
-function startHttpServer() {
+async function startHttpServer(): Promise<{ server: http.Server; port: number }> {
   const server = http.createServer((req, res) => {
     if (req.method !== 'POST' || !req.url?.startsWith('/mcp')) {
       res.writeHead(404, { 'Content-Type': 'text/plain' });
@@ -446,16 +447,35 @@ function startHttpServer() {
     });
   });
 
-  // ask_user can block indefinitely on a human reply; disable all idle timeouts.
   server.requestTimeout = 0;
   server.headersTimeout = 0;
   server.keepAliveTimeout = 0;
 
-  server.listen(HTTP_PORT, HTTP_HOST, () => {
-    console.error(`MCP HTTP server listening on http://${HTTP_HOST}:${HTTP_PORT}/mcp`);
-  });
+  for (let offset = 0; offset < HTTP_PORT_TRIES; offset++) {
+    const candidate = HTTP_PORT_START + offset;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (err: NodeJS.ErrnoException) => {
+          server.removeListener('listening', onListen);
+          reject(err);
+        };
+        const onListen = () => {
+          server.removeListener('error', onError);
+          resolve();
+        };
+        server.once('error', onError);
+        server.once('listening', onListen);
+        server.listen(candidate, HTTP_HOST);
+      });
+      console.error(`MCP HTTP server listening on http://${HTTP_HOST}:${candidate}/mcp`);
+      return { server, port: candidate };
+    } catch (err: any) {
+      if (err.code !== 'EADDRINUSE') throw err;
+      console.error(`Port ${candidate} in use, trying next`);
+    }
+  }
 
-  return server;
+  throw new Error(`No free port in range ${HTTP_PORT_START}-${HTTP_PORT_START + HTTP_PORT_TRIES - 1}`);
 }
 
 const shutdown = () => {
@@ -473,7 +493,7 @@ async function main() {
     console.error('Failed to initialize bot, exiting...');
     process.exit(1);
   }
-  startHttpServer();
+  await startHttpServer();
 }
 
 main().catch(error => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -564,6 +564,16 @@ async function startHttpServer(): Promise<{ server: http.Server; port: number }>
 }
 
 const cleanupState = () => {
+  // Only delete state files if we still own them. A leaked / zombie daemon
+  // exiting must not wipe the live daemon's PID/PORT (they may have been
+  // overwritten by a successor). TOCTOU race here is benign: worst case we
+  // skip a cleanup we should have done, ensure_daemon recovers next spawn.
+  try {
+    const recordedPid = fs.readFileSync(PID_FILE, 'utf8').trim();
+    if (recordedPid !== String(process.pid)) return;
+  } catch {
+    return;
+  }
   try { fs.unlinkSync(PID_FILE); } catch {}
   try { fs.unlinkSync(PORT_FILE); } catch {}
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -499,9 +499,11 @@ async function main() {
   }
   const { port } = await startHttpServer();
 
-  fs.mkdirSync(STATE_DIR, { recursive: true });
-  fs.writeFileSync(PID_FILE, `${process.pid}\n`);
-  fs.writeFileSync(PORT_FILE, `${port}\n`);
+  // mode 0o700 keeps server.log (which contains ask_user question/answer
+  // bodies) private on multi-user hosts.
+  fs.mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(PID_FILE, `${process.pid}\n`, { mode: 0o600 });
+  fs.writeFileSync(PORT_FILE, `${port}\n`, { mode: 0o600 });
   console.error(`State recorded: pid=${process.pid} port=${port} in ${STATE_DIR}`);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,13 @@ const PORT_FILE = path.join(STATE_DIR, 'server.port');
 
 const validatedChatId = CHAT_ID as string;
 let bot: TelegramBot | null = null;
-const pendingQuestions = new Map<string, (answer: string) => void>();
+
+interface PendingReply {
+  text: string;
+  chatId: number;
+  messageId: number;
+}
+const pendingQuestions = new Map<string, (reply: PendingReply) => void>();
 
 async function initializeBot() {
   try {
@@ -88,7 +94,11 @@ async function initializeBot() {
       if (questionId && pendingQuestions.has(questionId)) {
         console.error('Found matching question with ID:', questionId);
         const resolver = pendingQuestions.get(questionId)!;
-        resolver(msg.text);
+        resolver({
+          text: msg.text,
+          chatId: msg.chat.id,
+          messageId: msg.message_id,
+        });
         pendingQuestions.delete(questionId);
         console.error('Question resolved and removed from pending');
       } else {
@@ -139,7 +149,7 @@ async function notifyUser(params: NotifyUserParams): Promise<void> {
   }
 }
 
-async function askUser(params: AskUserParams): Promise<string> {
+async function askUser(params: AskUserParams): Promise<PendingReply> {
   if (!bot) {
     throw new Error('Bot not initialized');
   }
@@ -158,15 +168,36 @@ async function askUser(params: AskUserParams): Promise<string> {
     });
     console.error('Question sent successfully');
 
-    const response = await new Promise<string>((resolve) => {
+    const reply = await new Promise<PendingReply>((resolve) => {
       pendingQuestions.set(questionId, resolve);
     });
 
-    console.error('Received response:', response);
-    return response;
+    console.error('Received response:', reply.text);
+    return reply;
   } catch (error: any) {
     console.error('Error in askUser:', error);
     throw new Error(`Failed to get response: ${error.message}`);
+  }
+}
+
+// Acknowledge that the user's reply made it back to Claude Code by reacting
+// to *their* message with 👌. The contract callers rely on: if you see the
+// 👌 in Telegram, the ask_user tool call has unblocked on the CC side. So
+// this MUST run only after the JSON-RPC response is flushed to the wrapper.
+async function reactWithOk(chatId: number, messageId: number): Promise<void> {
+  const url = `https://api.telegram.org/bot${TELEGRAM_TOKEN}/setMessageReaction`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      chat_id: chatId,
+      message_id: messageId,
+      reaction: [{ type: 'emoji', emoji: '👌' }],
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '<no body>');
+    throw new Error(`setMessageReaction ${res.status}: ${body}`);
   }
 }
 
@@ -254,8 +285,16 @@ async function zipProject(params: { directory?: string } = {}): Promise<void> {
   }
 }
 
+// JSON-RPC dispatcher result. `postCommit` runs after the HTTP response has
+// been flushed to the wrapper, so callers can schedule effects that must be
+// observable to the user only AFTER Claude Code receives the tool result.
+type DispatchResult = {
+  response: any;
+  postCommit?: () => Promise<void>;
+};
+
 // JSON-RPC dispatcher: returns the response object, or null for notifications.
-async function dispatchRequest(request: any): Promise<any | null> {
+async function dispatchRequest(request: any): Promise<DispatchResult | null> {
   // JSON-RPC notifications have no `id` field and MUST NOT receive a response.
   if (!('id' in request)) {
     return null;
@@ -264,30 +303,33 @@ async function dispatchRequest(request: any): Promise<any | null> {
   switch (request.method) {
     case 'initialize':
       return {
-        jsonrpc: "2.0",
-        id: request.id,
-        result: {
-          protocolVersion: "2024-11-05",
-          serverInfo: {
-            name: "mcp-communicator-telegram",
-            version: "0.3.0"
-          },
-          capabilities: {
-            tools: {
-              listTools: true,
-              callTool: true
-            }
-          },
-          instructions: "Human-in-the-loop bridge to a real person over a Telegram chat."
+        response: {
+          jsonrpc: "2.0",
+          id: request.id,
+          result: {
+            protocolVersion: "2024-11-05",
+            serverInfo: {
+              name: "mcp-communicator-telegram",
+              version: "0.3.0"
+            },
+            capabilities: {
+              tools: {
+                listTools: true,
+                callTool: true
+              }
+            },
+            instructions: "Human-in-the-loop bridge to a real person over a Telegram chat."
+          }
         }
       };
 
     case 'tools/list':
       return {
-        jsonrpc: "2.0",
-        id: request.id,
-        result: {
-          tools: [
+        response: {
+          jsonrpc: "2.0",
+          id: request.id,
+          result: {
+            tools: [
             {
               name: "ask_user",
               description: "Ask the user a question via Telegram and wait for their response",
@@ -344,17 +386,28 @@ async function dispatchRequest(request: any): Promise<any | null> {
                 required: []
               }
             }
-          ]
+            ]
+          }
         }
       };
 
     case 'tools/call':
       try {
         let result: any;
+        let postCommit: (() => Promise<void>) | undefined;
         switch (request.params.name) {
           case 'ask_user': {
-            const answer = await askUser(request.params.arguments);
-            result = { content: [{ type: "text", text: answer }] };
+            const reply = await askUser(request.params.arguments);
+            result = { content: [{ type: "text", text: reply.text }] };
+            // Schedule the 👌 reaction for AFTER the response is flushed —
+            // see DispatchResult docstring and reactWithOk's contract.
+            postCommit = async () => {
+              try {
+                await reactWithOk(reply.chatId, reply.messageId);
+              } catch (err: any) {
+                console.error('Failed to react with 👌:', err?.message ?? err);
+              }
+            };
             break;
           }
           case 'notify_user': {
@@ -402,20 +455,27 @@ async function dispatchRequest(request: any): Promise<any | null> {
           default:
             throw new Error(`Unknown tool: ${request.params.name}`);
         }
-        return { jsonrpc: "2.0", id: request.id, result };
+        return {
+          response: { jsonrpc: "2.0", id: request.id, result },
+          postCommit,
+        };
       } catch (error: any) {
         return {
-          jsonrpc: "2.0",
-          id: request.id,
-          error: { code: -32000, message: error.message }
+          response: {
+            jsonrpc: "2.0",
+            id: request.id,
+            error: { code: -32000, message: error.message }
+          }
         };
       }
 
     default:
       return {
-        jsonrpc: "2.0",
-        id: request.id,
-        error: { code: -32601, message: `Method not found: ${request.method}` }
+        response: {
+          jsonrpc: "2.0",
+          id: request.id,
+          error: { code: -32601, message: `Method not found: ${request.method}` }
+        }
       };
   }
 }
@@ -446,13 +506,18 @@ async function startHttpServer(): Promise<{ server: http.Server; port: number }>
       }
 
       try {
-        const response = await dispatchRequest(request);
-        if (response === null) {
+        const dispatched = await dispatchRequest(request);
+        if (dispatched === null) {
           res.writeHead(202);
           res.end();
         } else {
           res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify(response));
+          // res.end(data, cb): cb fires once the body is flushed to the OS
+          // socket, which is the closest hook we have to "wrapper has the
+          // bytes in hand". postCommit must not run before this.
+          res.end(JSON.stringify(dispatched.response), () => {
+            dispatched.postCommit?.();
+          });
         }
       } catch (error: any) {
         console.error('Error handling request:', error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -564,10 +564,9 @@ async function startHttpServer(): Promise<{ server: http.Server; port: number }>
 }
 
 const cleanupState = () => {
-  // Only delete state files if we still own them. A leaked / zombie daemon
-  // exiting must not wipe the live daemon's PID/PORT (they may have been
-  // overwritten by a successor). TOCTOU race here is benign: worst case we
-  // skip a cleanup we should have done, ensure_daemon recovers next spawn.
+  // Skip cleanup if PID_FILE no longer names us — a zombie daemon must not
+  // wipe the live successor's state. TOCTOU race here is benign: worst case
+  // ensure_daemon respawns on the next request.
   try {
     const recordedPid = fs.readFileSync(PID_FILE, 'utf8').trim();
     if (recordedPid !== String(process.pid)) return;


### PR DESCRIPTION
This server currently fails the MCP init handshake under strict clients
like Claude Code CLI:

- `console.log` leaks non-JSON into stdout, so I switched to `console.error`.
- `notifications/initialized` has no `id`, but the `default` branch in
  `handleRequest` still replies with `-32601`; the client sees an orphan
  response and drops the connection. Now we skip any JSON-RPC message
  without an `id`.
- Also populated the optional `initialize.instructions` field.